### PR TITLE
feat: only expose README.md files as MCP resources

### DIFF
--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -117,10 +117,14 @@ def create_mcp_server(filesystem: FileSystem) -> FastMCP:
             )
         )
 
-    def _register_resource(path: str) -> None:
-        """Add a file to the MCP resource registry if it is a README.md."""
+    def _register_resource(path: str) -> bool:
+        """Add a file to the MCP resource registry if it is a README.md.
+
+        Returns:
+            True if a resource was registered, False otherwise.
+        """
         if not _is_resource_file(path):
-            return
+            return False
         uri = f"stash://{path}"
         mcp.add_resource(FunctionResource(
             uri=AnyUrl(uri), name=path,
@@ -128,11 +132,19 @@ def create_mcp_server(filesystem: FileSystem) -> FastMCP:
             mime_type=_get_mime_type(path),
             fn=lambda _fp=path: filesystem.read_file(_fp),
         ))
+        return True
 
-    def _unregister_resource(path: str) -> None:
-        """Remove a file from the MCP resource registry."""
+    def _unregister_resource(path: str) -> bool:
+        """Remove a file from the MCP resource registry.
+
+        Returns:
+            True if a resource was removed, False otherwise.
+        """
+        if not _is_resource_file(path):
+            return False
         uri_key = f"stash://{path}"
-        mcp._resource_manager._resources.pop(uri_key, None)
+        removed = mcp._resource_manager._resources.pop(uri_key, None)
+        return removed is not None
 
     # Resource template for dynamic access (resources/templates/list)
     @mcp.resource("stash://{path}", mime_type="text/plain", description="Read any file by path")
@@ -164,8 +176,8 @@ def create_mcp_server(filesystem: FileSystem) -> FastMCP:
                 f"File already exists: {path}. Use update_content to modify existing files."
             )
         filesystem.write_file(path, content)
-        _register_resource(path)
-        await ctx.send_resource_list_changed()
+        if _register_resource(path):
+            await ctx.send_resource_list_changed()
         emit(CONTENT_CREATED, path)
         logger.info(f"Created: {path}")
         return f"Created: {path}"
@@ -185,12 +197,13 @@ def create_mcp_server(filesystem: FileSystem) -> FastMCP:
         is_new = not filesystem.file_exists(path)
         filesystem.write_file(path, content)
         if is_new:
-            _register_resource(path)
-            await ctx.send_resource_list_changed()
+            if _register_resource(path):
+                await ctx.send_resource_list_changed()
             emit(CONTENT_CREATED, path)
         else:
-            uri = AnyUrl(f"stash://{path}")
-            await ctx.session.send_resource_updated(uri=uri)
+            if _is_resource_file(path):
+                uri = AnyUrl(f"stash://{path}")
+                await ctx.session.send_resource_updated(uri=uri)
             emit(CONTENT_UPDATED, path)
         logger.info(f"Updated: {path}")
         return f"Updated: {path}"
@@ -206,8 +219,8 @@ def create_mcp_server(filesystem: FileSystem) -> FastMCP:
             path: File path relative to content root
         """
         filesystem.delete_file(path)
-        _unregister_resource(path)
-        await ctx.send_resource_list_changed()
+        if _unregister_resource(path):
+            await ctx.send_resource_list_changed()
         emit(CONTENT_DELETED, path)
         logger.info(f"Deleted: {path}")
         return f"Deleted: {path}"
@@ -251,9 +264,10 @@ def create_mcp_server(filesystem: FileSystem) -> FastMCP:
             dest_path: New file path relative to content root
         """
         filesystem.move_file(source_path, dest_path)
-        _unregister_resource(source_path)
-        _register_resource(dest_path)
-        await ctx.send_resource_list_changed()
+        source_was_resource = _unregister_resource(source_path)
+        dest_is_resource = _register_resource(dest_path)
+        if source_was_resource or dest_is_resource:
+            await ctx.send_resource_list_changed()
         emit(CONTENT_MOVED, dest_path, source_path=source_path)
         logger.info(f"Moved: {source_path} -> {dest_path}")
         return f"Moved: {source_path} -> {dest_path}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -21,8 +21,8 @@ def temp_fs():
 @pytest.fixture
 def mcp_server(temp_fs):
     """Create a FastMCP server with temporary filesystem."""
-    temp_fs.write_file("test.md", "# Test Content")
-    temp_fs.write_file("docs/readme.md", "# README\nSome docs")
+    temp_fs.write_file("README.md", "# Root README")
+    temp_fs.write_file("docs/README.md", "# Docs README\nSome docs")
     temp_fs.write_file("data.json", '{"key": "value"}')
     return create_mcp_server(temp_fs)
 
@@ -70,24 +70,26 @@ def test_get_mime_type_default():
 
 
 async def test_list_resources(mcp_server):
-    """Test listing resources returns all files."""
+    """Test listing resources returns only README.md files."""
     resources = await mcp_server.get_resources()
     uris = list(resources.keys())
-    assert "stash://test.md" in uris
-    assert "stash://docs/readme.md" in uris
-    assert "stash://data.json" in uris
+    # Only README.md files should be registered as resources
+    assert "stash://README.md" in uris
+    assert "stash://docs/README.md" in uris
+    # Other files should NOT be in the resource list
+    assert "stash://data.json" not in uris
 
 
 async def test_resource_mime_types(mcp_server):
     """Test that resources have correct mime types."""
     resources = await mcp_server.get_resources()
-    md_resource = resources.get("stash://test.md")
+    md_resource = resources.get("stash://README.md")
     assert md_resource is not None
     assert md_resource.mime_type == "text/markdown"
 
+    # Non-README files should not be registered
     json_resource = resources.get("stash://data.json")
-    assert json_resource is not None
-    assert json_resource.mime_type == "application/json"
+    assert json_resource is None
 
 
 async def test_resource_templates(mcp_server):
@@ -98,10 +100,10 @@ async def test_resource_templates(mcp_server):
 
 async def test_read_resource_via_template(mcp_server):
     """Test reading a resource through the resource template."""
-    resource = await mcp_server.get_resource("stash://test.md")
-    # The resource object's fn reads the content
+    # README.md is registered, so it can be accessed
+    resource = await mcp_server.get_resource("stash://README.md")
     content = resource.fn()
-    assert content == "# Test Content"
+    assert content == "# Root README"
 
 
 # --- Tool tests ---
@@ -132,23 +134,23 @@ async def test_create_content_tool_existing_file(mcp_server, temp_fs, mock_conte
     """Test create_content tool errors on existing file."""
     tool = await mcp_server.get_tool("create_content")
     with pytest.raises(ValueError, match="already exists"):
-        await tool.run({"path": "test.md", "content": "overwrite"})
+        await tool.run({"path": "README.md", "content": "overwrite"})
 
 
 async def test_update_content_tool(mcp_server, temp_fs, mock_context):
     """Test update_content tool updates a file."""
     tool = await mcp_server.get_tool("update_content")
-    result = await tool.run({"path": "test.md", "content": "# Updated"})
-    assert "Updated: test.md" in str(result.content)
-    assert temp_fs.read_file("test.md") == "# Updated"
+    result = await tool.run({"path": "README.md", "content": "# Updated"})
+    assert "Updated: README.md" in str(result.content)
+    assert temp_fs.read_file("README.md") == "# Updated"
 
 
 async def test_delete_content_tool(mcp_server, temp_fs, mock_context):
     """Test delete_content tool deletes a file."""
     tool = await mcp_server.get_tool("delete_content")
-    result = await tool.run({"path": "test.md"})
-    assert "Deleted: test.md" in str(result.content)
-    assert not temp_fs.file_exists("test.md")
+    result = await tool.run({"path": "README.md"})
+    assert "Deleted: README.md" in str(result.content)
+    assert not temp_fs.file_exists("README.md")
 
 
 async def test_list_content_tool_recursive(mcp_server):
@@ -156,8 +158,8 @@ async def test_list_content_tool_recursive(mcp_server):
     tool = await mcp_server.get_tool("list_content")
     result = await tool.run({"recursive": True})
     text = str(result.content)
-    assert "test.md" in text
-    assert "docs/readme.md" in text
+    assert "README.md" in text
+    assert "docs/README.md" in text
     assert "data.json" in text
 
 
@@ -166,109 +168,169 @@ async def test_list_content_tool_non_recursive(mcp_server):
     tool = await mcp_server.get_tool("list_content")
     result = await tool.run({"path": "", "recursive": False})
     text = str(result.content)
-    assert "test.md" in text
+    assert "README.md" in text
     assert "docs" in text
 
 
 async def test_move_content_tool(mcp_server, temp_fs, mock_context):
     """Test move_content tool moves a file."""
     tool = await mcp_server.get_tool("move_content")
-    result = await tool.run({"source_path": "test.md", "dest_path": "moved.md"})
-    assert "Moved: test.md -> moved.md" in str(result.content)
-    assert not temp_fs.file_exists("test.md")
+    result = await tool.run({"source_path": "README.md", "dest_path": "moved.md"})
+    assert "Moved: README.md -> moved.md" in str(result.content)
+    assert not temp_fs.file_exists("README.md")
     assert temp_fs.file_exists("moved.md")
-    assert temp_fs.read_file("moved.md") == "# Test Content"
+    assert temp_fs.read_file("moved.md") == "# Root README"
 
 
 # --- Notification tests ---
 
 
 async def test_create_registers_resource(temp_fs, mock_context):
-    """Test that create_content registers the new resource."""
+    """Test that create_content registers README.md files as resources."""
     mcp = create_mcp_server(temp_fs)
     tool = await mcp.get_tool("create_content")
-    await tool.run({"path": "new.md", "content": "# New"})
+    # Create a README.md file
+    await tool.run({"path": "README.md", "content": "# New"})
     resources = await mcp.get_resources()
-    assert "stash://new.md" in resources
+    assert "stash://README.md" in resources
+
+    # Create a non-README file
+    await tool.run({"path": "other.md", "content": "# Other"})
+    resources = await mcp.get_resources()
+    # Non-README files should not be registered
+    assert "stash://other.md" not in resources
 
 
 async def test_create_sends_list_changed(temp_fs, mock_context):
-    """Test that create_content sends resource_list_changed notification."""
+    """Test that create_content sends resource_list_changed only for README.md files."""
     mcp = create_mcp_server(temp_fs)
     tool = await mcp.get_tool("create_content")
-    await tool.run({"path": "new.md", "content": "# New"})
+    
+    # Creating README.md should send notification
+    await tool.run({"path": "README.md", "content": "# New"})
     mock_context.send_resource_list_changed.assert_awaited_once()
+    
+    # Reset mock
+    mock_context.send_resource_list_changed.reset_mock()
+    
+    # Creating non-README file should NOT send notification
+    await tool.run({"path": "other.md", "content": "# Other"})
+    mock_context.send_resource_list_changed.assert_not_awaited()
 
 
 async def test_update_existing_sends_resource_updated(mcp_server, mock_context):
-    """Test that updating an existing file sends resource_updated notification."""
+    """Test that updating README.md sends resource_updated notification."""
     tool = await mcp_server.get_tool("update_content")
-    await tool.run({"path": "test.md", "content": "# Changed"})
+    
+    # Update README.md should send resource_updated
+    await tool.run({"path": "README.md", "content": "# Changed"})
     mock_context.session.send_resource_updated.assert_awaited_once()
     call_kwargs = mock_context.session.send_resource_updated.call_args
-    assert str(call_kwargs.kwargs["uri"]) == "stash://test.md"
-
-
-async def test_update_new_file_registers_resource(temp_fs, mock_context):
-    """Test that updating a non-existent file registers it as a new resource."""
-    mcp = create_mcp_server(temp_fs)
-    tool = await mcp.get_tool("update_content")
-    await tool.run({"path": "brand_new.md", "content": "# Brand New"})
-    resources = await mcp.get_resources()
-    assert "stash://brand_new.md" in resources
+    assert str(call_kwargs.kwargs["uri"]) == "stash://README.md"
+    
+    # Reset mock
+    mock_context.session.send_resource_updated.reset_mock()
+    
+    # Update non-README file should NOT send resource_updated
+    await tool.run({"path": "data.json", "content": '{"updated": true}'})
     mock_context.session.send_resource_updated.assert_not_awaited()
 
 
-async def test_update_new_file_sends_list_changed(temp_fs, mock_context):
-    """Test that updating a non-existent file sends resource_list_changed notification."""
+async def test_update_new_file_registers_resource(temp_fs, mock_context):
+    """Test that updating a non-existent README.md registers it as a resource."""
     mcp = create_mcp_server(temp_fs)
     tool = await mcp.get_tool("update_content")
-    await tool.run({"path": "brand_new.md", "content": "# Brand New"})
+    
+    # Create new README.md via update
+    await tool.run({"path": "new/README.md", "content": "# Brand New"})
+    resources = await mcp.get_resources()
+    assert "stash://new/README.md" in resources
+    mock_context.session.send_resource_updated.assert_not_awaited()
+    
+    # Create new non-README file via update
+    await tool.run({"path": "other.md", "content": "# Other"})
+    resources = await mcp.get_resources()
+    assert "stash://other.md" not in resources
+
+
+async def test_update_new_file_sends_list_changed(temp_fs, mock_context):
+    """Test that creating a new README.md sends resource_list_changed."""
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("update_content")
+    
+    # Creating new README.md should send notification
+    await tool.run({"path": "new/README.md", "content": "# Brand New"})
     mock_context.send_resource_list_changed.assert_awaited_once()
+    
+    # Reset mock
+    mock_context.send_resource_list_changed.reset_mock()
+    
+    # Creating new non-README file should NOT send notification
+    await tool.run({"path": "other.md", "content": "# Other"})
+    mock_context.send_resource_list_changed.assert_not_awaited()
 
 
 async def test_delete_unregisters_resource(mcp_server, temp_fs, mock_context):
-    """Test that delete_content removes the resource from registry."""
+    """Test that delete_content removes README.md from registry."""
     resources_before = await mcp_server.get_resources()
-    assert "stash://test.md" in resources_before
+    assert "stash://README.md" in resources_before
 
     tool = await mcp_server.get_tool("delete_content")
-    await tool.run({"path": "test.md"})
+    await tool.run({"path": "README.md"})
 
     resources_after = await mcp_server.get_resources()
-    assert "stash://test.md" not in resources_after
+    assert "stash://README.md" not in resources_after
 
 
 async def test_delete_sends_list_changed(mcp_server, temp_fs, mock_context):
-    """Test that delete_content sends resource_list_changed notification."""
+    """Test that delete_content sends notification only for README.md."""
     tool = await mcp_server.get_tool("delete_content")
-    await tool.run({"path": "test.md"})
+    
+    # Deleting README.md should send notification
+    await tool.run({"path": "README.md"})
     mock_context.send_resource_list_changed.assert_awaited_once()
+    
+    # Reset mock
+    mock_context.send_resource_list_changed.reset_mock()
+    
+    # Deleting non-README file should NOT send notification
+    await tool.run({"path": "data.json"})
+    mock_context.send_resource_list_changed.assert_not_awaited()
 
 
 async def test_move_updates_resources(mcp_server, temp_fs, mock_context):
-    """Test that move_content removes old resource and adds new one."""
+    """Test that move_content updates resource registry for README.md."""
     tool = await mcp_server.get_tool("move_content")
-    await tool.run({"source_path": "test.md", "dest_path": "moved.md"})
-
+    
+    # Moving README.md to another README.md location
+    await tool.run({"source_path": "README.md", "dest_path": "other/README.md"})
     resources = await mcp_server.get_resources()
-    assert "stash://test.md" not in resources
-    assert "stash://moved.md" in resources
+    assert "stash://README.md" not in resources
+    assert "stash://other/README.md" in resources
 
 
 async def test_move_sends_list_changed(mcp_server, temp_fs, mock_context):
-    """Test that move_content sends resource_list_changed notification."""
+    """Test that move_content sends notification when README.md is involved."""
     tool = await mcp_server.get_tool("move_content")
-    await tool.run({"source_path": "test.md", "dest_path": "moved.md"})
+    
+    # Moving README.md to another location should send notification
+    await tool.run({"source_path": "README.md", "dest_path": "other/README.md"})
     mock_context.send_resource_list_changed.assert_awaited_once()
+    
+    # Reset mock
+    mock_context.send_resource_list_changed.reset_mock()
+    
+    # Moving non-README file should NOT send notification
+    await tool.run({"source_path": "data.json", "dest_path": "moved.json"})
+    mock_context.send_resource_list_changed.assert_not_awaited()
 
 
 async def test_resources_filtered_by_include_patterns(temp_fs):
-    """Test that when patterns are set, only matching files are registered as MCP resources."""
+    """Test that only README.md files matching patterns are registered as MCP resources."""
     # Write files of different types
+    temp_fs.write_file("docs/README.md", "# Docs README")
     temp_fs.write_file("docs/guide.md", "# Guide")
-    temp_fs.write_file("docs/api.md", "# API")
-    temp_fs.write_file("notes/todo.txt", "todo items")
+    temp_fs.write_file("notes/README.md", "# Notes README")
     temp_fs.write_file("data.json", '{"key": "value"}')
 
     # Create a new filesystem with patterns, using the same content directory
@@ -278,13 +340,12 @@ async def test_resources_filtered_by_include_patterns(temp_fs):
     resources = await mcp.get_resources()
     uris = list(resources.keys())
 
-    # Only docs/*.md should be registered
-    assert "stash://docs/guide.md" in uris
-    assert "stash://docs/api.md" in uris
-    # These should NOT be registered
-    assert "stash://notes/todo.txt" not in uris
-    assert "stash://data.json" not in uris
-    assert "stash://test.md" not in uris
+    # Only docs/README.md should be registered (it's both README.md and matches pattern)
+    assert "stash://docs/README.md" in uris
+    # These should NOT be registered (either not README.md or don't match pattern)
+    assert "stash://docs/guide.md" not in uris  # Not README.md
+    assert "stash://notes/README.md" not in uris  # Doesn't match pattern
+    assert "stash://data.json" not in uris  # Not README.md
 
 
 async def test_tools_emit_events(mcp_server, temp_fs, mock_context):


### PR DESCRIPTION
This pull request refines how files are exposed as MCP resources in the `stash_mcp/mcp_server.py` module. The main change is to restrict MCP resources to only `README.md` files, while other files remain accessible through tools and resource templates. This helps clarify resource exposure and improves security and organization.

Resource exposure restriction:

* Introduced the `RESOURCE_FILENAME` constant and the `_is_resource_file` function to ensure only `README.md` files are exposed as MCP resources.
* Updated the resource registration logic in the `lifespan` function so that only files matching `README.md` are registered as MCP resources, skipping all others. [[1]](diffhunk://#diff-76faac657ce6b152d3beb3ba8e64b3d3550a1da6b230f5e7dad52dfe2078d6dcL89-R101) [[2]](diffhunk://#diff-76faac657ce6b152d3beb3ba8e64b3d3550a1da6b230f5e7dad52dfe2078d6dcL107-R120)

Code organization:

* Moved the import of `PurePosixPath` to the top of the file for consistency and clarity.Only files named README.md are registered in the MCP resource list. All other files remain accessible via tools (create, update, list, etc.) and the stash://{path} resource template for dynamic reads.

This keeps the client's context window lean -- README.md files serve as directory indexes, and agents use Stash tools to access deeper content.