### PR TITLE
Add docker-compose.search-local.yml and docker-compose.search-openai.yml

### DIFF
--- a/docker-compose.search-local.yml
+++ b/docker-compose.search-local.yml
@@ -1,0 +1,17 @@
+services:
+  stash-mcp:
+    build: .
+    container_name: stash-mcp
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./content:/data/content
+      - ./stash-index:/data/stash-index
+    environment:
+      - STASH_CONTENT_ROOT=/data/content
+      - STASH_HOST=0.0.0.0
+      - STASH_PORT=8000
+      - STASH_SEARCH_ENABLED=true
+      - STASH_SEARCH_INDEX_DIR=/data/stash-index
+      - STASH_SEARCH_EMBEDDER_MODEL=sentence-transformers:all-mpnet-base-v2
+    restart: unless-stopped

--- a/docker-compose.search-openai.yml
+++ b/docker-compose.search-openai.yml
@@ -1,0 +1,22 @@
+services:
+  stash-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SEARCH_EXTRA: search-openai
+    container_name: stash-mcp
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./content:/data/content
+      - ./stash-index:/data/stash-index
+    environment:
+      - STASH_CONTENT_ROOT=/data/content
+      - STASH_HOST=0.0.0.0
+      - STASH_PORT=8000
+      - STASH_SEARCH_ENABLED=true
+      - STASH_SEARCH_INDEX_DIR=/data/stash-index
+      - STASH_SEARCH_EMBEDDER_MODEL=openai:text-embedding-3-large
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ search = [
 ]
 search-openai = [
     "numpy>=1.26.0",
+    "openai==2.21.0",
+    "tiktoken==0.12.0",
     "pydantic-ai-slim[openai]>=0.1.0",
 ]
 search-cohere = [


### PR DESCRIPTION
This pull request introduces new Docker Compose configurations for running the `stash-mcp` service with different search backends and updates the Python dependencies to support OpenAI-based embedding. The main changes add support for both local and OpenAI-powered semantic search, with appropriate environment configuration and dependency management.

**Docker Compose configuration for different search backends:**

* Added `docker-compose.search-local.yml` to configure `stash-mcp` for local semantic search using the `sentence-transformers:all-mpnet-base-v2` model, including volume mounts and environment variables for local indexing.
* Added `docker-compose.search-openai.yml` to configure `stash-mcp` for semantic search using OpenAI embeddings (`openai:text-embedding-3-large`), with support for passing the `OPENAI_API_KEY` and appropriate build arguments.

**Python dependency updates for OpenAI support:**

* Updated the `search-openai` extra in `pyproject.toml` to include `openai==2.21.0` and `tiktoken==0.12.0` as dependencies, enabling the use of OpenAI embedding models.