### PR TITLE
fix: use asyncio.to_thread for synchronous file reads in tool handlers

### DIFF
--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -1,5 +1,6 @@
 """MCP Server implementation for Stash using FastMCP."""
 
+import asyncio
 import functools
 import hashlib
 import logging
@@ -553,7 +554,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             A dict with 'content' (file text), 'sha' (SHA-256 hex digest of
             the FULL file), and 'truncated' (bool)
         """
-        content = filesystem.read_file(path)
+        content = await asyncio.to_thread(filesystem.read_file, path)
         sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
         truncated = False
         if max_lines is not None:
@@ -601,7 +602,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
         results = []
         for path in paths:
             try:
-                content = filesystem.read_file(path)
+                content = await asyncio.to_thread(filesystem.read_file, path)
                 sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
                 truncated = False
                 if max_lines is not None:


### PR DESCRIPTION
## Summary

- `read_content` and `read_content_batch` call `filesystem.read_file()` (synchronous `Path.read_text()`) directly inside `async def` tool handlers
- This blocks the event loop, which stalls the MCP SDK's message router and prevents concurrent response delivery
- Under parallel tool calls (6-8 simultaneous), this causes head-of-line blocking — `search_content` completes in ~300ms while `read_content` hangs indefinitely

## Fix

Wrap `filesystem.read_file()` in `asyncio.to_thread()` in both `read_content` and `read_content_batch`. Same pattern already used for git operations elsewhere in the codebase (e.g., `git_backend.log`).

## Test plan

- [ ] Verify `read_content` still returns correct content and SHA
- [ ] Verify `read_content_batch` still returns correct results for multiple files
- [ ] Test with concurrent tool calls (6+ parallel requests) to confirm no blocking