### PR TITLE
Add token key rotation, audit logging, and manual membership precedence

### DIFF
--- a/docs/auth/01-persistence.md
+++ b/docs/auth/01-persistence.md
@@ -89,14 +89,26 @@ DATABASE_URL: str = os.getenv(
     "sqlite+aiosqlite:////data/stash-auth.db",
 )
 
-# HMAC key used to hash API tokens at rest. Required when AUTH is enabled
-# (validated in 02). Read it here so it's available to db/auth modules
-# regardless of whether middleware has been wired up yet.
-AUTH_TOKEN_HMAC_KEY: str | None = os.getenv("STASH_AUTH_TOKEN_HMAC_KEY")
+# HMAC keys for API tokens. Comma-separated list — the FIRST entry is the
+# active signer; the rest are accepted on verify so an operator can rotate
+# without invalidating live tokens. Each api_tokens row records which key
+# index hashed it (key_version column) so verification can route to the
+# right key directly instead of trying all of them.
+#
+# Operators rolling forward: prepend a new key, restart.  After enough
+# time for any caller to refresh, drop the old key from the tail.
+#
+# Required when AUTH is enabled (validated in 02). Read it here so it's
+# available to db/auth modules regardless of whether middleware has been
+# wired up yet.
+AUTH_TOKEN_HMAC_KEYS: list[str] = [
+    k.strip() for k in os.getenv("STASH_AUTH_TOKEN_HMAC_KEYS", "").split(",")
+    if k.strip()
+]
 ```
 
-No runtime validation in this chunk — 02 will fail-fast if AUTH is on without
-the HMAC key set.
+No runtime validation in this chunk — 02 will fail-fast if AUTH is on with
+an empty key list.
 
 ### Schema
 
@@ -142,27 +154,54 @@ api_tokens
   id            UUID PK
   user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE
   token_hash    TEXT UNIQUE NOT NULL    -- HMAC-SHA256 of the secret part
+  key_version   SMALLINT NOT NULL       -- index into AUTH_TOKEN_HMAC_KEYS used to hash this row
   name          TEXT NOT NULL           -- human label
   scopes        TEXT NOT NULL           -- comma-joined; v1 just "read,write,admin"
   expires_at    TIMESTAMPTZ
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
   last_used_at  TIMESTAMPTZ
   revoked_at    TIMESTAMPTZ
+
+audit_events
+  id            UUID PK
+  occurred_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+  actor_user_id UUID REFERENCES users(id) ON DELETE SET NULL   -- nullable for system actors (OIDC group sync)
+  actor_kind    TEXT NOT NULL CHECK (actor_kind IN ('user','system','api_token'))
+  action        TEXT NOT NULL           -- e.g. 'token.issued', 'membership.granted'
+  target_kind   TEXT                    -- 'token','membership','store','tenant','user'
+  target_id     TEXT                    -- UUID-as-text; left flexible since some targets predate their rows
+  tenant_id     UUID REFERENCES tenants(id) ON DELETE SET NULL  -- scope, when applicable
+  detail        TEXT                    -- JSON-as-text; small structured payload, no secrets
 ```
 
 Notes:
 
 - `memberships.source` distinguishes group-claim-derived rows (refreshed on
   every OIDC login) from manually granted rows (used for users who don't
-  match any OIDC group but were added via admin API). v1 only writes
-  `oidc_group`, but the column is in the schema so 05 can add manual grants
-  without a migration.
+  match any OIDC group but were added via admin API). **Precedence is
+  locked in the README: manual wins.** If a `(user_id, tenant_id)` row
+  exists with `source='manual'`, the OIDC login skips the
+  group-derived upsert entirely — no role change, no source flip. Tests
+  in 02 must exercise this. `manual` rows are only created/deleted
+  through the admin API in 05.
 - `stores.git_remote_url` is nullable because the on-disk repo may be local-
   only. When the registry initializes a store with no remote, it creates a
   bare init (no clone).
 - `api_tokens.scopes` is a flat comma-joined string for v1 simplicity. If
   we need richer scopes later we can swap to a JSON column without a data
   migration (SQLite TEXT and Postgres JSONB both round-trip strings fine).
+- `api_tokens.key_version` records which entry in `AUTH_TOKEN_HMAC_KEYS`
+  hashed this row. Verify path reads the key at that index; mint path
+  always writes `key_version=0` (the active signer). If the key at the
+  recorded index has been removed from the env list, verification fails
+  closed — the operator chose to invalidate that key.
+- `audit_events` is append-only. No UPDATE or DELETE issued by application
+  code; only DBA tooling touches it. Listed actions for v1:
+  `token.issued`, `token.revoked`, `membership.granted` (manual),
+  `membership.revoked` (manual), `membership.synced` (OIDC group →
+  role created/changed/deleted), `store.provisioned`, `store.deleted`,
+  `tenant.created`, `tenant.deleted`. `detail` carries a small JSON
+  payload — never the token secret, never the HMAC, never the JWT.
 
 ### `stash_mcp/db/engine.py`
 
@@ -303,13 +342,25 @@ def generate_token() -> str:
     return TOKEN_PREFIX + secrets.token_urlsafe(TOKEN_RANDOM_BYTES)
 
 def hash_token(token: str, *, key: str) -> str:
-    """HMAC-SHA256 of the token using the deployment's HMAC key.
-    Returns hex digest. The key is never persisted with the hash."""
+    """HMAC-SHA256 of the token using one deployment HMAC key.
+    Returns hex digest. Callers use ``hash_with_active_key`` for new tokens
+    and ``verify_token`` for existing rows."""
     return hmac.new(key.encode("utf-8"), token.encode("utf-8"), hashlib.sha256).hexdigest()
 
-def verify_token(token: str, expected_hash: str, *, key: str) -> bool:
-    """Constant-time comparison."""
-    return hmac.compare_digest(hash_token(token, key=key), expected_hash)
+def hash_with_active_key(token: str, *, keys: list[str]) -> tuple[str, int]:
+    """Hash with keys[0]. Returns (hash, key_version=0). Caller persists both."""
+    if not keys:
+        raise ValueError("AUTH_TOKEN_HMAC_KEYS is empty")
+    return hash_token(token, key=keys[0]), 0
+
+def verify_token(
+    token: str, expected_hash: str, *, keys: list[str], key_version: int,
+) -> bool:
+    """Constant-time comparison against the key recorded for this row.
+    Fails closed if the recorded key has been rotated out of the list."""
+    if key_version < 0 or key_version >= len(keys):
+        return False
+    return hmac.compare_digest(hash_token(token, key=keys[key_version]), expected_hash)
 
 def looks_like_stash_token(value: str) -> bool:
     """Cheap prefix check so the ApiTokenAuthProvider can skip JWT-shaped values."""
@@ -335,17 +386,30 @@ Or document `alembic upgrade head` in the spec for 06.
 ## Test plan
 
 - `tests/auth/test_token_hashing.py`
-  - Round-trip: generate → hash → verify true with same key.
-  - Wrong key → verify false.
+  - Round-trip: generate → `hash_with_active_key` → verify true with the
+    same keys list and recorded key_version.
+  - Verify with `key_version=0` against a keys list whose [0] entry has
+    rotated → verify false (fails closed).
+  - Rotation: hash with `keys=[K1]`, then verify with `keys=[K2, K1]` and
+    `key_version=1` → true (old key still accepted because still in list).
+  - Out-of-range `key_version` → verify false (no IndexError).
   - Tampered token → verify false.
   - Constant-time comparison doesn't short-circuit (smoke test).
   - `looks_like_stash_token` true/false on shaped/unshaped values.
 - `tests/db/test_models_roundtrip.py`
-  - Spin up an in-memory SQLite engine (`sqlite+aiosqlite:///:memory:`).
+  - Spin up SQLite via `create_async_engine(..., poolclass=StaticPool,
+    connect_args={"check_same_thread": False})` against
+    `sqlite+aiosqlite:///:memory:` so all connections share the in-memory
+    DB. (Without StaticPool, each connection gets its own DB and tests
+    silently see empty state.)
   - Run Alembic upgrade head against it.
   - Insert one of each entity and read it back; verify FK constraints
     reject orphaned memberships.
   - `UNIQUE (tenant_id, slug)` on `stores` rejects duplicates.
+  - `api_tokens.key_version` round-trips as smallint.
+  - `audit_events` insert with `actor_user_id=NULL` (system actor) and
+    with a real user_id; both read back; deleting the user sets
+    `actor_user_id=NULL` (ON DELETE SET NULL).
 
 No tests for the Principal class — it's a dataclass; `has_role_on` is
 exercised in 02's middleware tests.
@@ -353,7 +417,8 @@ exercised in 02's middleware tests.
 ## Acceptance
 
 - `uv run alembic upgrade head` against a fresh sqlite file produces the
-  five tables with all constraints.
+  six tables (tenants, users, memberships, stores, api_tokens,
+  audit_events) with all constraints.
 - `uv run pytest tests/auth tests/db` passes.
 - `ruff check stash_mcp/auth stash_mcp/db` clean.
 - Importing `stash_mcp.main` still works (no eager DB connections — engine
@@ -373,5 +438,10 @@ None. Everything in this chunk is mechanical given the locked decisions in
 - When generating the Alembic baseline, hand-write it from `models.py`
   rather than autogenerating — autogeneration's diff output is noisy and
   this is the first migration, so we want it readable.
-- `Config.AUTH_TOKEN_HMAC_KEY` is `str | None` here on purpose. 02 will
-  validate it's set when auth is on.
+- `Config.AUTH_TOKEN_HMAC_KEYS` is a `list[str]` here and may be empty —
+  02 fails-fast when auth is on and the list is empty. Token mint always
+  writes `key_version=0`; verify uses the row's recorded `key_version`.
+- The `audit_events` table is created in this chunk but **nothing writes
+  to it yet**. Writers land alongside the actions they record: 02 writes
+  `membership.synced`, 05 writes `token.*`, `membership.{granted,revoked}`,
+  `store.*`, `tenant.*`. This keeps 01 mechanical (schema only).

--- a/docs/auth/02-providers-middleware.md
+++ b/docs/auth/02-providers-middleware.md
@@ -233,15 +233,31 @@ Key responsibilities:
 - Extract claims. Read `sub`, `email`, `name` (or `preferred_username` as
   fallback). Read the configured `OIDC_GROUPS_CLAIM` from claims.
 - Upsert `users` row by `oidc_sub`. Update `last_login_at`.
-- Refresh `memberships` for this user from the groups claim:
-  - If `OIDC_ADMIN_GROUP` is in the user's groups, upsert a
+- Refresh `memberships` for this user from the groups claim. **Manual
+  wins** (locked in `README.md`):
+  - For each tenant the user already has a `source='manual'` row on,
+    **skip the group-derived upsert entirely** — no role change, no
+    source flip, no delete. Manual is sticky.
+  - For tenants without a manual row: if `OIDC_ADMIN_GROUP` is in the
+    user's groups, upsert
     `memberships(user_id, tenant_id=<default tenant>, role='admin',
-    source='oidc_group')` row.
-  - For groups not matching, delete any `memberships(source='oidc_group')`
-    rows that no longer apply. Don't touch `source='manual'` rows.
+    source='oidc_group')`. If the user's previous group-derived role
+    differs, write an `audit_events` row with `action='membership.synced'`
+    and `detail={"old_role": ..., "new_role": "admin"}`.
+  - Delete any `memberships(source='oidc_group')` rows whose groups
+    are no longer present in the claim. Write an `audit_events` row
+    with `action='membership.synced'` and
+    `detail={"old_role": ..., "new_role": null}` for each deletion.
+  - Never touch `source='manual'` rows.
   - v1 only mints admin memberships from groups. Non-admin tenant
     memberships come via the admin API in 05.
-- Build and return `Principal`.
+- Build and return `Principal`. **Caching note:** wrap the upsert +
+  membership refresh in a small async LRU keyed by `(sub, iat)` (or
+  `jti` if present) so MCP clients hammering tools at high rate don't
+  re-hit the DB on every call. Cache TTL = `min(exp - iat, 5min)`. The
+  cache stores the built `Principal`. Returning a cached Principal also
+  skips the `last_login_at` UPDATE — accept staleness within one JWT
+  lifetime.
 
 A "default tenant" is auto-created if it doesn't exist — slug `default`,
 display_name `Default tenant`. This is the tenant that admin memberships
@@ -385,11 +401,23 @@ sees them).
   - Unknown `kid` triggers JWKS refresh; second call succeeds.
   - Membership refresh: pre-existing `oidc_group` membership for a removed
     group is deleted; `manual` membership for the same tenant is preserved.
+  - **Manual wins (D5 regression):** user has `source='manual', role='member'`
+    on default tenant and is in `OIDC_ADMIN_GROUP`. After login, the row
+    is unchanged (still member, still manual) and **no** `oidc_group`
+    row is created for the same tenant.
+  - **Audit on group sync:** group-derived role added → `audit_events`
+    row with `action='membership.synced'`, `actor_kind='system'`,
+    `detail` carries old/new roles. Group-derived role removed → another
+    audit row with `new_role: null`.
+  - **JWT cache:** two consecutive auths with the same JWT make exactly
+    one DB upsert. Different `iat` (re-issued JWT) bypasses the cache.
 - `tests/auth/test_api_token_provider.py`
   - Valid token → Principal with `auth_method='api_token'`.
   - Revoked token → AuthError.
   - Expired token → AuthError.
-  - Wrong HMAC key (simulating key rotation gone wrong) → returns None.
+  - Rotated key path: token row has `key_version=1`, env keys list is
+    `[K2, K1]` → verify succeeds against `keys[1]=K1`.
+  - Token row `key_version` not in keys list (rotated out) → AuthError.
   - Non-stash prefix → returns None (no AuthError).
 - `tests/auth/test_session_provider.py`
   - Cookie roundtrip → same user.

--- a/docs/auth/05-admin-cli.md
+++ b/docs/auth/05-admin-cli.md
@@ -302,6 +302,13 @@ The `token` field appears ONLY in the POST response. Subsequent GETs
 return `{"id": ..., "name": ..., "last_used_at": ...}` without the
 secret.
 
+Every successful mint writes `audit_events(action='token.issued',
+actor_user_id=<minter>, actor_kind='user', target_kind='token',
+target_id=<new token id>, detail={"name": ..., "scopes": [...],
+"expires_at": ...})`. Revoke writes `action='token.revoked'`. The
+audit row is committed in the same transaction as the token-row
+change, so the audit log can't drift from the table state.
+
 ### `/admin/*` endpoints
 
 All under `Depends(require_admin)` which checks `principal.has_role_on(<default tenant>, "admin")`. In v1 admin is global (granted on the
@@ -337,6 +344,21 @@ on-disk directory. The on-disk delete is recursive and final — there's
 no soft-delete. Document this in the response with a confirmation flag:
 `DELETE /admin/tenants/{id}/stores/{slug}?confirm=true`. Without
 `confirm=true`, returns 400.
+
+**Audit writes for `/admin/*`:**
+| Action | Endpoint |
+|---|---|
+| `tenant.created` | `POST /admin/tenants` |
+| `tenant.deleted` | `DELETE /admin/tenants/{id}` |
+| `store.provisioned` | `POST /admin/tenants/{id}/stores` |
+| `store.deleted` | `DELETE /admin/tenants/{id}/stores/{slug}` (the row that survives the cascade) |
+| `membership.granted` | `POST /admin/memberships` |
+| `membership.revoked` | `DELETE /admin/memberships/{id}` |
+| `user.deleted` | `DELETE /admin/users/{id}` |
+
+All audit rows carry `actor_user_id=<admin>`, `actor_kind='user'`, and
+the `tenant_id` of the affected scope where applicable. Same
+"committed in the same transaction" rule as token mint.
 
 ### CLI
 

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -38,7 +38,23 @@ the specs below. Cite this file if anything tries to deviate.
 - **Persistence:** SQLAlchemy 2.x async + Alembic. SQLite for dev, Postgres
   for prod — swap via `DATABASE_URL`. Auth state in SQL; content stays
   file/git.
-- **Token hashing:** HMAC-SHA256 (no password hashing needed — no passwords).
+- **Token hashing:** HMAC-SHA256 with **versioned keys**. `api_tokens.key_version`
+  smallint stores which key hashed each row. `STASH_AUTH_TOKEN_HMAC_KEYS` is
+  a comma-separated list — the first entry is the active signer, the rest
+  are accepted on verify so a rotation doesn't invalidate live tokens. New
+  rows always write `key_version=<index of first key>`. Rolling forward is
+  prepend-and-restart; rolling back the list drops the keys at the end.
+- **Membership precedence:** OIDC-group-derived and manual memberships
+  collide on `UNIQUE (user_id, tenant_id)`. **Manual wins.** On OIDC
+  login, if a `source='manual'` row exists for the user on a tenant, the
+  group-derived upsert is *skipped* (no role change, no source flip).
+  Group churn is therefore invisible to manually-granted users — this is
+  intentional: manual grants are an escape hatch and shouldn't silently
+  flip back when the IdP's groups change.
+- **Audit log:** an `audit_events` table in the v1 schema records token
+  issuance/revocation, manual membership grants, OIDC group-derived role
+  changes, store provisioning, and store deletion. Append-only, no UI in
+  v1 — consumed via SQL by operators. Schema in `01-persistence.md`.
 - **Routing:** Path-based. `/mcp/<tenant>/<store>/` and `/api/<tenant>/<store>/*`.
   Both slugs are on the wire — tenant is *not* inferred from the principal,
   because a user may be a member of multiple tenants.


### PR DESCRIPTION
## Summary

This PR extends the auth schema and token handling to support key rotation, audit logging, and establishes that manually-granted memberships take precedence over OIDC-derived ones. The changes are primarily documentation and specification updates that define the implementation contract for subsequent PRs.

## Key Changes

- **Token key rotation:** Replace single `AUTH_TOKEN_HMAC_KEY` with `AUTH_TOKEN_HMAC_KEYS` (comma-separated list). The first entry is the active signer; remaining entries are accepted during verification. Add `api_tokens.key_version` column to record which key hashed each token, enabling rotation without invalidating live tokens.

- **Token hashing API:** Introduce `hash_with_active_key(token, keys)` for minting new tokens (always writes `key_version=0`). Update `verify_token()` to accept `keys` list and `key_version` parameter, failing closed if the recorded key has been rotated out.

- **Audit events table:** Add append-only `audit_events` table to record token issuance/revocation, manual membership grants/revocations, OIDC group-derived role changes, and store/tenant provisioning. Includes `actor_kind` (user/system/api_token), `action`, `target_kind`, and JSON `detail` payload.

- **Manual membership precedence:** Establish that `source='manual'` memberships are sticky — on OIDC login, if a manual row exists for a user on a tenant, the group-derived upsert is skipped entirely (no role change, no source flip). This prevents group churn from silently overriding manual grants.

- **JWT caching in OIDC provider:** Add small async LRU cache (keyed by `sub, iat` or `jti`) to avoid re-hitting the DB on high-rate tool calls within a single JWT lifetime. Cache TTL = `min(exp - iat, 5min)`.

## Notable Implementation Details

- `api_tokens.key_version` is a SMALLINT; out-of-range values cause verification to fail closed (no IndexError).
- `audit_events` is created in schema but **not written to yet** — writers land alongside the actions they record (02 for membership sync, 05 for token/membership/store/tenant actions).
- `Config.AUTH_TOKEN_HMAC_KEYS` is a `list[str]` that may be empty; 02 fails-fast when auth is enabled with an empty list.
- Manual membership precedence is locked in README and must be exercised in 02's test suite.
- All audit writes are committed in the same transaction as the entity change to prevent drift.

https://claude.ai/code/session_01TvSDfKbDMxVVTpYytdSAW4