### PR TITLE
Spec 03: Add StoreRegistry for per-store resource management

### DIFF
--- a/stash_mcp/config.py
+++ b/stash_mcp/config.py
@@ -135,6 +135,11 @@ class Config:
     # request and the rest of the auth env (OIDC + HMAC + session) must be set.
     AUTH_ENABLED: bool = os.getenv("STASH_AUTH_ENABLED", "false").lower() == "true"
 
+    # Slug used for the implicit single store when AUTH_ENABLED=False. The
+    # legacy single-CONTENT_DIR layout is exposed under this slug so that
+    # URLs and admin tooling can refer to it uniformly once auth is flipped on.
+    DEFAULT_STORE_SLUG: str = os.getenv("STASH_DEFAULT_STORE_SLUG", "default")
+
     # OIDC config. Discovery URL is the only required entry — everything else
     # (authorize/token/jwks/userinfo URLs) is read from the well-known doc.
     OIDC_DISCOVERY_URL: str | None = os.getenv("STASH_OIDC_DISCOVERY_URL")

--- a/stash_mcp/git_backend.py
+++ b/stash_mcp/git_backend.py
@@ -477,6 +477,70 @@ class GitBackend:
         logger.info("Pushed %s to %s/%s.", branch, remote, branch)
 
     @classmethod
+    def init(
+        cls,
+        target_dir: Path,
+        author_default: str = "stash-mcp <stash@local>",
+    ) -> "GitBackend":
+        """Initialise an empty git repository in *target_dir*.
+
+        Creates the directory if it does not exist, runs ``git init``,
+        sets a local committer identity, and records a root commit so
+        the repo has a HEAD that transactions can reset against.
+
+        Returns a :class:`GitBackend` pointed at the new repo.
+
+        Raises:
+            RuntimeError: If ``git init`` or the root commit fails.
+        """
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        init_result = subprocess.run(
+            ["git", "init", "--initial-branch=main", str(target_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if init_result.returncode != 0:
+            # Older git lacks --initial-branch; fall back to plain init.
+            init_result = subprocess.run(
+                ["git", "init", str(target_dir)],
+                capture_output=True,
+                text=True,
+            )
+        if init_result.returncode != 0:
+            raise RuntimeError(
+                f"git init failed for {target_dir}: {init_result.stderr.strip()}"
+            )
+
+        instance = cls(target_dir, author_default=author_default)
+        instance.validate()
+
+        # Empty root commit so HEAD exists — transactions reset against it.
+        # `-c commit.gpgsign=false` keeps the root commit usable in
+        # environments where the user has a (possibly misconfigured) global
+        # signing setup; per-store repos created by Stash don't need signed
+        # commits.
+        commit_result = instance._run(
+            [
+                "git",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ]
+        )
+        if commit_result.returncode != 0:
+            raise RuntimeError(
+                f"git initial commit failed for {target_dir}: "
+                f"{commit_result.stderr.strip()}"
+            )
+
+        logger.info("Initialised empty git repo at %s", target_dir)
+        return instance
+
+    @classmethod
     def clone(
         cls,
         url: str,

--- a/stash_mcp/main.py
+++ b/stash_mcp/main.py
@@ -7,6 +7,8 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -21,6 +23,8 @@ from .filesystem import FileSystem
 from .frontend import FRONTEND_DIR, mount_frontend
 from .mcp_server import create_mcp_server
 from .metrics import get_metrics, init_metrics
+from .stores.layout import validate_content_layout
+from .stores.registry import get_store_registry
 from .ui import create_ui_router
 
 # Configure logging
@@ -232,9 +236,62 @@ async def _git_sync_loop(
         await asyncio.sleep(interval)
 
 
+def _create_auth_enabled_app() -> FastAPI:
+    """Minimal app scaffold for AUTH_ENABLED=True.
+
+    Routing into per-store ``/api/<tenant>/<store>/*`` and
+    ``/mcp/<tenant>/<store>/`` lives in spec 04. Until that lands, ``/api``
+    and ``/mcp`` return 503 so misconfigured deployments fail loudly
+    instead of silently serving the wrong content. The auth middleware
+    still runs, so the UI redirect-to-login flow from spec 02 keeps
+    working.
+    """
+    # Touch the registry so it's instantiated and ready for 04 to consume.
+    get_store_registry()
+
+    app = FastAPI()
+
+    async def _not_wired() -> JSONResponse:
+        return JSONResponse(
+            {
+                "error": "service_unavailable",
+                "detail": (
+                    "STASH_AUTH_ENABLED=true: per-store routing has not been "
+                    "wired in this build. See docs/auth/04-routing.md."
+                ),
+            },
+            status_code=503,
+        )
+
+    @app.get("/api/health")
+    async def _health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    _methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+    app.add_api_route("/api/{path:path}", _not_wired, methods=_methods)
+    app.add_api_route("/mcp", _not_wired, methods=_methods)
+    app.add_api_route("/mcp/{path:path}", _not_wired, methods=_methods)
+
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    auth_providers = [
+        SessionCookieAuthProvider(),
+        ApiTokenAuthProvider(),
+        OIDCAuthProvider(),
+    ]
+    app.add_middleware(StashAuthMiddleware, providers=auth_providers)
+    return app
+
+
 def create_app():
     """Create and configure the FastAPI application."""
-    Config.validate_auth_config()
+    validate_content_layout()
+
+    if Config.AUTH_ENABLED:
+        Config.validate_auth_config()
+        return _create_auth_enabled_app()
+
     _maybe_clone_repo()
     Config.ensure_content_dir()
     filesystem = FileSystem(Config.CONTENT_DIR, include_patterns=Config.CONTENT_PATHS)
@@ -375,19 +432,7 @@ def create_app():
 
     app.add_middleware(_MCPSlashMiddleware)
 
-    # Auth middleware sits in front of both /api and /mcp. When
-    # AUTH_ENABLED=false it short-circuits and existing behavior is preserved.
-    # Provider order is intentional: cookies are cheapest to check, API tokens
-    # next, JWT validation (with JWKS + crypto) most expensive — the middleware
-    # short-circuits on the first success.
-    if Config.AUTH_ENABLED:
-        auth_providers = [
-            SessionCookieAuthProvider(),
-            ApiTokenAuthProvider(),
-            OIDCAuthProvider(),
-        ]
-        app.add_middleware(StashAuthMiddleware, providers=auth_providers)
-
+    # Auth middleware is only wired in the AUTH_ENABLED branch above.
     # Wire event bus: REST mutations emit MCP resource notifications
     def on_content_changed(event_type: str, path: str, **kwargs: str) -> None:
         logger.info(f"Content event: {event_type} {path} {kwargs}")

--- a/stash_mcp/stores/__init__.py
+++ b/stash_mcp/stores/__init__.py
@@ -1,0 +1,7 @@
+"""Per-store content layer.
+
+Spec 03 introduces a :class:`StoreRegistry` that resolves a
+``(tenant_slug, store_slug)`` pair to a fully-wired bundle of
+``FileSystem`` / ``GitBackend`` / ``TransactionManager``. The actual HTTP
+routing that consults the registry lives in spec 04.
+"""

--- a/stash_mcp/stores/layout.py
+++ b/stash_mcp/stores/layout.py
@@ -1,0 +1,84 @@
+"""CONTENT_DIR shape invariant + path resolver for the per-store layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..config import Config
+
+
+class ContentLayoutError(SystemExit):
+    """Raised at startup when CONTENT_DIR shape disagrees with AUTH_ENABLED."""
+
+
+def validate_content_layout() -> None:
+    """Refuse to start if the directory shape disagrees with AUTH_ENABLED.
+
+    AUTH_ENABLED=True requires CONTENT_DIR to either be empty or contain
+    only ``<tenant>/<store>/``-shaped subdirectories. Any top-level file
+    or a single-level subdirectory triggers refusal.
+
+    AUTH_ENABLED=False requires CONTENT_DIR to NOT be in
+    ``<tenant>/<store>/`` shape — operators flipping AUTH on/off
+    mid-deployment is the bug we're catching. Migration path: stand up a
+    fresh content dir, copy content into a tenant/store, then enable
+    auth.
+    """
+    root = Config.CONTENT_DIR
+    root.mkdir(parents=True, exist_ok=True)
+
+    children = [p for p in root.iterdir() if not p.name.startswith(".")]
+    if not children:
+        return
+
+    has_tenant_shape = _looks_tenant_shaped(children)
+
+    if Config.AUTH_ENABLED:
+        if not has_tenant_shape:
+            raise ContentLayoutError(
+                f"STASH_AUTH_ENABLED=true but {root} contains content that is "
+                "not in <tenant>/<store>/ layout. Stash refuses to mix layouts; "
+                "see docs/auth/README.md."
+            )
+    else:
+        if has_tenant_shape:
+            raise ContentLayoutError(
+                f"STASH_AUTH_ENABLED=false but {root} appears to be in "
+                "<tenant>/<store>/ layout. Set STASH_AUTH_ENABLED=true or "
+                "use a different content dir."
+            )
+
+
+def _looks_tenant_shaped(children: list[Path]) -> bool:
+    """Heuristic: every visible top-level entry is a directory, and any
+    contents inside it are themselves directories — those are the stores.
+
+    An empty tenant directory IS valid: ``tenant create`` provisions a
+    row but doesn't touch disk, so a freshly-restarted server may also
+    see no tenant dirs at all. The on-disk dir is created lazily by the
+    first ``store provision`` for that tenant.
+
+    Dotfiles (``.git``, ``.DS_Store``, etc.) at any level are ignored by
+    the caller before we get here.
+    """
+    if not children:
+        return True
+    for tenant_dir in children:
+        if not tenant_dir.is_dir():
+            return False
+        stores = [s for s in tenant_dir.iterdir() if not s.name.startswith(".")]
+        for store_dir in stores:
+            if not store_dir.is_dir():
+                return False
+    return True
+
+
+def store_root(tenant_id: str, store_slug: str) -> Path:
+    """Absolute path to a store's content root.
+
+    ``tenant_id`` is the tenant UUID (as a string) — directory names are
+    UUIDs, not slugs, so renaming a tenant slug doesn't require moving
+    files. ``store_slug`` is the store's slug; renaming a store DOES
+    move the directory (callers in 05 handle that).
+    """
+    return Config.CONTENT_DIR / tenant_id / store_slug

--- a/stash_mcp/stores/registry.py
+++ b/stash_mcp/stores/registry.py
@@ -1,0 +1,179 @@
+"""Per-store :class:`FileSystem` / :class:`GitBackend` / :class:`TransactionManager`
+bundle, resolved lazily by ``(tenant_slug, store_slug)``.
+
+The registry is process-wide. In a multi-pod deployment each pod has
+its own instance and lazy-loads what it needs — the DB is the source of
+truth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+
+from ..config import Config
+from ..db.models import Store, Tenant
+from ..db.session import get_sessionmaker
+from ..filesystem import FileSystem
+from ..git_backend import GitBackend
+from ..transactions import TransactionManager
+from .layout import store_root
+
+logger = logging.getLogger(__name__)
+
+
+class StoreNotProvisionedError(RuntimeError):
+    """Store row exists but the on-disk repo is missing."""
+
+
+class StoreAlreadyProvisionedError(RuntimeError):
+    """``provision()`` called against a path that already has content."""
+
+
+@dataclass
+class LoadedStore:
+    tenant_id: UUID
+    tenant_slug: str
+    store_id: UUID
+    store_slug: str
+    filesystem: FileSystem
+    git_backend: GitBackend | None
+    transaction_manager: TransactionManager | None
+
+    @property
+    def fs_for_mcp(self) -> FileSystem | TransactionManager:
+        """The FileSystem MCP tools and REST handlers should use — the
+        transaction-wrapped form when writes are enabled, otherwise the
+        bare filesystem."""
+        return self.transaction_manager or self.filesystem
+
+
+class StoreRegistry:
+    def __init__(self) -> None:
+        self._stores: dict[tuple[str, str], LoadedStore] = {}
+        self._lock = asyncio.Lock()
+
+    async def _load(self, tenant_slug: str, store_slug: str) -> LoadedStore:
+        async with get_sessionmaker()() as session:
+            stmt = (
+                select(Store, Tenant)
+                .join(Tenant, Tenant.id == Store.tenant_id)
+                .where(Tenant.slug == tenant_slug, Store.slug == store_slug)
+            )
+            row = (await session.execute(stmt)).one_or_none()
+            if row is None:
+                raise KeyError(f"store {tenant_slug}/{store_slug} not found")
+            store, tenant = row
+
+        root = store_root(str(tenant.id), store_slug)
+        if not root.exists():
+            raise StoreNotProvisionedError(
+                f"store {tenant.slug}/{store_slug} has a row but no on-disk "
+                f"repo at {root}"
+            )
+
+        fs = FileSystem(root, include_patterns=Config.CONTENT_PATHS)
+        git: GitBackend | None = None
+        txn: TransactionManager | None = None
+        if (root / ".git").exists():
+            git = GitBackend(root, author_default=Config.GIT_AUTHOR_DEFAULT)
+            git.validate()
+            if not Config.READ_ONLY:
+                txn = TransactionManager(fs, git)
+
+        logger.info(
+            "Loaded store %s/%s from %s (git=%s, txn=%s)",
+            tenant_slug,
+            store_slug,
+            root,
+            git is not None,
+            txn is not None,
+        )
+        return LoadedStore(
+            tenant_id=tenant.id,
+            tenant_slug=tenant.slug,
+            store_id=store.id,
+            store_slug=store.slug,
+            filesystem=fs,
+            git_backend=git,
+            transaction_manager=txn,
+        )
+
+    async def get(self, tenant_slug: str, store_slug: str) -> LoadedStore:
+        """Resolve by ``(tenant_slug, store_slug)``. Caches the result.
+
+        The slug → UUID translation happens inside ``_load``. Cache is
+        keyed by slug because a slug rename invalidates the URL anyway
+        — callers in 05 invalidate the entry on rename.
+        """
+        key = (tenant_slug, store_slug)
+        cached = self._stores.get(key)
+        if cached is not None:
+            return cached
+        async with self._lock:
+            cached = self._stores.get(key)
+            if cached is not None:
+                return cached
+            loaded = await self._load(tenant_slug, store_slug)
+            self._stores[key] = loaded
+            return loaded
+
+    async def provision(
+        self,
+        *,
+        tenant_id: UUID,
+        tenant_slug: str,
+        store_slug: str,
+        git_remote_url: str | None,
+        git_branch: str = "main",
+    ) -> LoadedStore:
+        """Create the on-disk repo for a store row (called by admin API in 05).
+
+        Either clones from ``git_remote_url`` or runs ``git init``. Caller
+        passes both ``tenant_id`` (for the on-disk path) and
+        ``tenant_slug`` (for the cache key) — admin endpoints already
+        have both, so we don't re-query.
+        """
+        root = store_root(str(tenant_id), store_slug)
+        if root.exists() and any(root.iterdir()):
+            raise StoreAlreadyProvisionedError(str(root))
+        root.mkdir(parents=True, exist_ok=True)
+
+        if git_remote_url:
+            GitBackend.clone(
+                url=git_remote_url,
+                target_dir=root,
+                branch=git_branch,
+                token=Config.GIT_SYNC_TOKEN,
+                recursive=Config.GIT_SYNC_RECURSIVE,
+            )
+        else:
+            GitBackend.init(root, author_default=Config.GIT_AUTHOR_DEFAULT)
+
+        return await self.get(tenant_slug, store_slug)
+
+    def invalidate(self, tenant_slug: str, store_slug: str) -> None:
+        """Drop a cached :class:`LoadedStore`. Used after store deletion,
+        a remote-URL change, or a tenant-slug rename (callers invalidate
+        every cached store under the old slug)."""
+        self._stores.pop((tenant_slug, store_slug), None)
+
+
+_registry: StoreRegistry | None = None
+
+
+def get_store_registry() -> StoreRegistry:
+    global _registry
+    if _registry is None:
+        _registry = StoreRegistry()
+    return _registry
+
+
+def reset_store_registry() -> None:
+    """Drop the process-wide registry. Test-only."""
+    global _registry
+    _registry = None

--- a/tests/stores/test_layout.py
+++ b/tests/stores/test_layout.py
@@ -1,0 +1,135 @@
+"""Tests for the CONTENT_DIR shape invariant in ``stash_mcp.stores.layout``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from stash_mcp.config import Config
+from stash_mcp.stores.layout import (
+    ContentLayoutError,
+    store_root,
+    validate_content_layout,
+)
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    return root
+
+
+def _set_auth(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
+    monkeypatch.setattr(Config, "AUTH_ENABLED", enabled, raising=False)
+
+
+def test_auth_off_empty_dir_ok(content_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _set_auth(monkeypatch, False)
+    validate_content_layout()  # no raise
+
+
+def test_auth_off_flat_content_ok(content_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _set_auth(monkeypatch, False)
+    (content_dir / "README.md").write_text("hi")
+    (content_dir / "notes").mkdir()
+    (content_dir / "notes" / "a.md").write_text("a")
+    validate_content_layout()  # no raise
+
+
+def test_auth_off_tenant_shaped_raises(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _set_auth(monkeypatch, False)
+    (content_dir / "tenant-uuid" / "docs").mkdir(parents=True)
+    with pytest.raises(ContentLayoutError):
+        validate_content_layout()
+
+
+def test_auth_on_empty_dir_ok(content_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _set_auth(monkeypatch, True)
+    validate_content_layout()
+
+
+def test_auth_on_flat_content_raises(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _set_auth(monkeypatch, True)
+    (content_dir / "README.md").write_text("hi")
+    with pytest.raises(ContentLayoutError):
+        validate_content_layout()
+
+
+def test_auth_on_top_level_file_raises(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _set_auth(monkeypatch, True)
+    (content_dir / "stray.txt").write_text("oops")
+    with pytest.raises(ContentLayoutError):
+        validate_content_layout()
+
+
+def test_auth_on_tenant_shaped_ok(content_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _set_auth(monkeypatch, True)
+    (content_dir / "tenant-a" / "docs").mkdir(parents=True)
+    (content_dir / "tenant-a" / "docs" / "x.md").write_text("x")
+    validate_content_layout()
+
+
+def test_auth_on_empty_tenant_dir_ok(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """B1 regression: ``tenant create`` writes a row but no on-disk dir; a
+    deployment that later restarts may also have empty tenant dirs after
+    stores are removed. Either way, the layout check must accept this."""
+    _set_auth(monkeypatch, True)
+    (content_dir / "tenant-a").mkdir()
+    validate_content_layout()
+
+
+def test_auth_on_mixed_empty_and_populated_tenants_ok(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _set_auth(monkeypatch, True)
+    (content_dir / "tenant-empty").mkdir()
+    (content_dir / "tenant-full" / "docs").mkdir(parents=True)
+    (content_dir / "tenant-full" / "notes").mkdir()
+    validate_content_layout()
+
+
+def test_dotfiles_ignored(content_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _set_auth(monkeypatch, True)
+    (content_dir / ".git").mkdir()
+    (content_dir / ".DS_Store").write_text("")
+    (content_dir / "tenant-a" / "docs").mkdir(parents=True)
+    (content_dir / "tenant-a" / ".git").mkdir()
+    (content_dir / "tenant-a" / "docs" / ".cache").mkdir()
+    validate_content_layout()
+
+
+def test_auth_off_dotfiles_only_ok(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _set_auth(monkeypatch, False)
+    (content_dir / ".hidden").write_text("")
+    validate_content_layout()
+
+
+def test_store_root_uses_uuid_then_slug(
+    content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    p = store_root("11111111-1111-1111-1111-111111111111", "docs")
+    assert p == content_dir / "11111111-1111-1111-1111-111111111111" / "docs"
+
+
+def test_validate_creates_missing_content_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    root = tmp_path / "not-yet"
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    _set_auth(monkeypatch, False)
+    assert not root.exists()
+    validate_content_layout()
+    assert root.is_dir()

--- a/tests/stores/test_registry.py
+++ b/tests/stores/test_registry.py
@@ -1,0 +1,247 @@
+"""Tests for ``stash_mcp.stores.registry.StoreRegistry``.
+
+Uses the shared ``auth_db`` fixture (in-memory SQLite) so the registry
+can read ``stores`` rows via the real ``get_sessionmaker``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from stash_mcp.config import Config
+from stash_mcp.db import engine as engine_mod
+from stash_mcp.db import session as session_mod
+from stash_mcp.db.models import Base, Store, Tenant
+from stash_mcp.git_backend import GitBackend
+from stash_mcp.stores import registry as registry_mod
+from stash_mcp.stores.registry import (
+    StoreAlreadyProvisionedError,
+    StoreNotProvisionedError,
+    StoreRegistry,
+)
+from stash_mcp.transactions import TransactionManager
+
+
+def _enable_sqlite_fks(engine: AsyncEngine) -> None:
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_pragma(dbapi_connection, _record):  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+@pytest.fixture
+async def auth_db(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[
+    async_sessionmaker[AsyncSession]
+]:
+    test_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    _enable_sqlite_fks(test_engine)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    test_sessionmaker = async_sessionmaker(
+        test_engine, expire_on_commit=False, class_=AsyncSession
+    )
+    monkeypatch.setattr(engine_mod, "_engine", test_engine, raising=False)
+    monkeypatch.setattr(session_mod, "_sessionmaker", test_sessionmaker, raising=False)
+    try:
+        yield test_sessionmaker
+    finally:
+        await test_engine.dispose()
+        monkeypatch.setattr(engine_mod, "_engine", None, raising=False)
+        monkeypatch.setattr(session_mod, "_sessionmaker", None, raising=False)
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    monkeypatch.setattr(Config, "READ_ONLY", False, raising=False)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_singleton(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+    yield
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+
+
+async def _make_tenant_and_store(
+    sm: async_sessionmaker[AsyncSession], *, tenant_slug: str = "acme", store_slug: str = "docs"
+) -> tuple[Tenant, Store]:
+    async with sm() as session:
+        tenant = Tenant(slug=tenant_slug, display_name=tenant_slug.title())
+        session.add(tenant)
+        await session.flush()
+        store = Store(
+            tenant_id=tenant.id,
+            slug=store_slug,
+            display_name=store_slug.title(),
+            git_branch="main",
+        )
+        session.add(store)
+        await session.commit()
+        await session.refresh(tenant)
+        await session.refresh(store)
+        return tenant, store
+
+
+async def test_get_loads_store_with_on_disk_repo(
+    auth_db, content_dir: Path
+):
+    tenant, _store = await _make_tenant_and_store(auth_db)
+    repo_root = content_dir / str(tenant.id) / "docs"
+    GitBackend.init(repo_root, author_default="test <t@x>")
+
+    reg = StoreRegistry()
+    loaded = await reg.get("acme", "docs")
+    assert loaded.tenant_slug == "acme"
+    assert loaded.store_slug == "docs"
+    assert loaded.filesystem.content_dir == repo_root.resolve()
+    assert loaded.git_backend is not None
+    assert loaded.transaction_manager is not None
+    assert isinstance(loaded.transaction_manager, TransactionManager)
+    assert loaded.fs_for_mcp is loaded.transaction_manager
+
+
+async def test_get_caches_loaded_store(auth_db, content_dir: Path):
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    reg = StoreRegistry()
+    a = await reg.get("acme", "docs")
+    b = await reg.get("acme", "docs")
+    assert a is b
+
+
+async def test_invalidate_triggers_reload(auth_db, content_dir: Path):
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    reg = StoreRegistry()
+    first = await reg.get("acme", "docs")
+    reg.invalidate("acme", "docs")
+    second = await reg.get("acme", "docs")
+    assert first is not second
+
+
+async def test_provision_creates_init_repo(auth_db, content_dir: Path):
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    repo_root = content_dir / str(tenant.id) / "docs"
+    assert not repo_root.exists()
+
+    reg = StoreRegistry()
+    loaded = await reg.provision(
+        tenant_id=tenant.id,
+        tenant_slug=tenant.slug,
+        store_slug="docs",
+        git_remote_url=None,
+    )
+    assert (repo_root / ".git").is_dir()
+    assert loaded.git_backend is not None
+    assert loaded.transaction_manager is not None
+
+
+async def test_provision_raises_when_dir_already_populated(
+    auth_db, content_dir: Path
+):
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    repo_root = content_dir / str(tenant.id) / "docs"
+    repo_root.mkdir(parents=True)
+    (repo_root / "stray.txt").write_text("hello")
+
+    reg = StoreRegistry()
+    with pytest.raises(StoreAlreadyProvisionedError):
+        await reg.provision(
+            tenant_id=tenant.id,
+            tenant_slug=tenant.slug,
+            store_slug="docs",
+            git_remote_url=None,
+        )
+
+
+async def test_get_unknown_store_raises_key_error(auth_db, content_dir: Path):
+    reg = StoreRegistry()
+    with pytest.raises(KeyError):
+        await reg.get("ghost", "docs")
+
+
+async def test_get_with_missing_on_disk_repo_raises(auth_db, content_dir: Path):
+    await _make_tenant_and_store(auth_db)
+    # Do NOT create the directory.
+
+    reg = StoreRegistry()
+    with pytest.raises(StoreNotProvisionedError):
+        await reg.get("acme", "docs")
+
+
+async def test_concurrent_gets_load_once(
+    auth_db, content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    reg = StoreRegistry()
+    call_count = 0
+    real_load = reg._load
+
+    async def slow_load(tenant_slug: str, store_slug: str):
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.05)
+        return await real_load(tenant_slug, store_slug)
+
+    monkeypatch.setattr(reg, "_load", slow_load)
+
+    results = await asyncio.gather(
+        reg.get("acme", "docs"),
+        reg.get("acme", "docs"),
+        reg.get("acme", "docs"),
+    )
+    assert call_count == 1
+    assert results[0] is results[1] is results[2]
+
+
+async def test_read_only_skips_transaction_manager(
+    auth_db, content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(Config, "READ_ONLY", True, raising=False)
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    reg = StoreRegistry()
+    loaded = await reg.get("acme", "docs")
+    assert loaded.git_backend is not None
+    assert loaded.transaction_manager is None
+    assert loaded.fs_for_mcp is loaded.filesystem
+
+
+async def test_no_git_dir_means_no_backend(auth_db, content_dir: Path):
+    tenant, _ = await _make_tenant_and_store(auth_db)
+    # Create the store dir but DON'T git-init it.
+    (content_dir / str(tenant.id) / "docs").mkdir(parents=True)
+
+    reg = StoreRegistry()
+    loaded = await reg.get("acme", "docs")
+    assert loaded.git_backend is None
+    assert loaded.transaction_manager is None
+    assert loaded.fs_for_mcp is loaded.filesystem


### PR DESCRIPTION
## Summary
Implements spec 03 by introducing a `StoreRegistry` that lazily loads and caches per-store bundles of `FileSystem`, `GitBackend`, and `TransactionManager` instances. This enables multi-tenant, multi-store deployments where each store's resources are resolved on-demand by `(tenant_slug, store_slug)` pairs.

## Key Changes

- **New `StoreRegistry` class** (`stash_mcp/stores/registry.py`):
  - Lazy-loads stores by querying the database for tenant/store rows
  - Caches `LoadedStore` instances keyed by `(tenant_slug, store_slug)`
  - Handles concurrent requests with async locking to ensure single load per store
  - Provides `get()` for loading cached stores, `provision()` for creating new on-disk repos, and `invalidate()` for cache invalidation
  - Respects `READ_ONLY` config to conditionally wire `TransactionManager`
  - Exposes `fs_for_mcp` property that returns transaction-wrapped or bare filesystem based on write mode

- **New `stash_mcp/stores/layout.py`**:
  - Validates `CONTENT_DIR` shape at startup: enforces `<tenant_id>/<store_slug>/` layout when `AUTH_ENABLED=true`, flat layout when `false`
  - Provides `store_root()` helper to resolve absolute paths using tenant UUID and store slug
  - Prevents accidental mixing of auth-enabled and auth-disabled layouts

- **Extended `GitBackend.init()` classmethod**:
  - Creates empty git repositories with initial commit
  - Supports fallback for older git versions lacking `--initial-branch`
  - Disables GPG signing for auto-created repos

- **Updated `main.py`**:
  - Calls `validate_content_layout()` at startup
  - Adds `_create_auth_enabled_app()` that scaffolds a minimal FastAPI app for `AUTH_ENABLED=true` deployments
  - Returns 503 for `/api` and `/mcp` routes until spec 04 wires per-store routing
  - Instantiates `StoreRegistry` early so it's ready for spec 04 consumption
  - Moves auth middleware setup into the auth-enabled branch

- **Comprehensive test suite** (`tests/stores/test_registry.py`, `tests/stores/test_layout.py`):
  - Tests store loading, caching, and invalidation
  - Tests provision flow with git init and error handling
  - Tests concurrent load deduplication
  - Tests read-only mode behavior
  - Tests layout validation for both auth modes

## Notable Implementation Details

- The registry is process-wide (singleton) and each pod in a multi-pod deployment has its own instance; the database is the source of truth
- Cache keys use slugs (not UUIDs) because slug renames invalidate URLs anyway
- Concurrent `get()` calls for the same store load once via async locking
- `LoadedStore.fs_for_mcp` abstracts whether MCP tools use bare filesystem or transaction-wrapped version
- Git backend is optional: stores without `.git/` directory load successfully but without version control

https://claude.ai/code/session_018tt3rJBNq66Ahkg5gzhUwv