### PR TITLE
Implement per-store routing and multi-tenant isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop-*
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Configure git for tests
+        run: |
+          git config --global user.name "ci"
+          git config --global user.email "ci@example.com"
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Test
+        run: uv run pytest -q

--- a/stash_mcp/api.py
+++ b/stash_mcp/api.py
@@ -5,8 +5,9 @@ import logging
 import time
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
+from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -14,7 +15,6 @@ from .config import Config
 from .events import CONTENT_CREATED, CONTENT_DELETED, CONTENT_MOVED, CONTENT_UPDATED, emit
 from .filesystem import (
     FileNotFoundError,
-    FileSystem,
     FileSystemError,
     InvalidPathError,
 )
@@ -22,6 +22,12 @@ from .mcp_server import MIME_TYPES
 from .metrics import get_metrics
 
 logger = logging.getLogger(__name__)
+
+
+USE_CURRENT_STORE: Any = object()
+"""Sentinel passed to :func:`create_api` in auth mode — handlers then
+resolve the filesystem from :func:`current_store` at request time
+instead of closing over a single FS."""
 
 
 def _get_mime_type(path: str) -> str:
@@ -68,7 +74,7 @@ class TreeNode(BaseModel):
 
 
 def create_api(
-    filesystem: FileSystem,
+    filesystem_or_resolver,
     lifespan=None,
     search_engine=None,
     git_backend=None,
@@ -78,9 +84,15 @@ def create_api(
     """Create FastAPI application.
 
     Args:
-        filesystem: Filesystem instance
+        filesystem_or_resolver: Either a :class:`FileSystem` (legacy
+            single-store mode) or the :data:`USE_CURRENT_STORE` sentinel
+            (auth mode, where handlers resolve the FS from
+            :func:`current_store` at request time).
         lifespan: Optional lifespan context manager for the app
         search_engine: Optional SearchEngine instance for semantic search
+        git_backend: Optional GitBackend instance (legacy mode only)
+        git_overview_remote: Git remote for overview comparison
+        git_overview_branch: Git branch for overview comparison
 
     Returns:
         FastAPI application
@@ -101,6 +113,75 @@ def create_api(
         allow_headers=["*"],
     )
 
+    def _fs():
+        """Resolve the FileSystem for the in-flight request.
+
+        Returns the bare :class:`FileSystem` — REST writes are *not*
+        wrapped in a transaction (MCP tools own that lifecycle). This
+        matches legacy mode where ``main.py`` passes the bare filesystem
+        directly to the API.
+        """
+        if filesystem_or_resolver is USE_CURRENT_STORE:
+            from .routing.context import require_store
+
+            return require_store().filesystem
+        return filesystem_or_resolver
+
+    def _bare_fs():
+        """Same as :func:`_fs` — kept for symmetry with the
+        path-resolution / stat helpers below."""
+        return _fs()
+
+    def _git_backend():
+        """Resolve the git backend for the in-flight request, if any."""
+        if filesystem_or_resolver is USE_CURRENT_STORE:
+            from .routing.context import current_store
+
+            store = current_store()
+            return store.git_backend if store is not None else None
+        return git_backend
+
+    def _etag(path: str) -> str:
+        """Compute the strong ETag for a content path."""
+        gb = _git_backend()
+        if gb is not None:
+            return gb.hash_object(path)
+        return _bare_fs().content_hash(path)
+
+    def _quoted(etag: str) -> str:
+        """Wrap a hex digest in quotes — strong ETag form."""
+        return f'"{etag}"'
+
+    def _if_match_matches(header: str | None, current_etag: str) -> bool:
+        """Return True when an ``If-Match`` header includes *current_etag*.
+
+        Comma-separated lists and ``*`` (any) are honoured.
+        """
+        if header is None:
+            return True
+        header = header.strip()
+        if header == "*":
+            return True
+        quoted = _quoted(current_etag)
+        for value in (v.strip() for v in header.split(",")):
+            if value == quoted or value == current_etag:
+                return True
+        return False
+
+    def _if_none_match_matches(header: str | None, current_etag: str) -> bool:
+        """Return True when an ``If-None-Match`` header includes
+        *current_etag* (so caller should get a 304)."""
+        if header is None:
+            return False
+        header = header.strip()
+        if header == "*":
+            return True
+        quoted = _quoted(current_etag)
+        for value in (v.strip() for v in header.split(",")):
+            if value == quoted or value == current_etag:
+                return True
+        return False
+
     @app.middleware("http")
     async def _metrics_middleware(request: Request, call_next):
         t0 = time.perf_counter()
@@ -117,7 +198,7 @@ def create_api(
     def _get_updated_at(relative_path: str) -> str | None:
         """Get file modification time as ISO string."""
         try:
-            full_path = filesystem._resolve_path(relative_path)
+            full_path = _bare_fs()._resolve_path(relative_path)
             if full_path.exists() and full_path.is_file():
                 mtime = full_path.stat().st_mtime
                 return datetime.fromtimestamp(mtime, tz=UTC).isoformat()
@@ -129,8 +210,9 @@ def create_api(
         """Build a recursive directory tree."""
         name = PurePosixPath(relative_path).name if relative_path else "root"
         node = TreeNode(name=name, path=relative_path, type="directory", children=[])
+        fs = _fs()
         try:
-            for item_name, is_dir in filesystem.list_files(relative_path):
+            for item_name, is_dir in fs.list_files(relative_path):
                 child_path = f"{relative_path}/{item_name}" if relative_path else item_name
                 if is_dir:
                     node.children.append(_build_tree(child_path))
@@ -183,11 +265,11 @@ def create_api(
             recursive: If true, list all files recursively
             file_type: Filter by file extension (e.g. ".md", ".txt")
         """
+        fs = _fs()
         try:
             items = []
             if recursive:
-                # List all files recursively
-                for file_path in filesystem.list_all_files(path):
+                for file_path in fs.list_all_files(path):
                     if file_type and not file_path.endswith(file_type):
                         continue
                     items.append(
@@ -199,8 +281,7 @@ def create_api(
                         )
                     )
             else:
-                # List directory contents (shallow)
-                for name, is_dir in filesystem.list_files(path):
+                for name, is_dir in fs.list_files(path):
                     item_path = f"{path}/{name}" if path else name
                     if file_type and not is_dir and not name.endswith(file_type):
                         continue
@@ -222,18 +303,25 @@ def create_api(
             logger.error(f"Error listing content: {e}")
             raise HTTPException(status_code=500, detail="Internal server error")
 
-    @app.get("/api/content/{path:path}", response_model=ContentItem)
-    async def read_content(path: str):
-        """Read content file."""
+    @app.get("/api/content/{path:path}")
+    async def read_content(path: str, request: Request, response: Response):
+        """Read content file. Returns 304 when ``If-None-Match`` matches."""
+        fs = _fs()
         try:
-            content = filesystem.read_file(path)
-            return ContentItem(
+            content = fs.read_file(path)
+            etag = _etag(path)
+            quoted = _quoted(etag)
+            if _if_none_match_matches(request.headers.get("if-none-match"), etag):
+                return Response(status_code=304, headers={"ETag": quoted})
+            response.headers["ETag"] = quoted
+            item = ContentItem(
                 path=path,
                 is_directory=False,
                 content=content,
                 mime_type=_get_mime_type(path),
                 updated_at=_get_updated_at(path),
             )
+            return item
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="File not found")
         except InvalidPathError as e:
@@ -243,16 +331,21 @@ def create_api(
             raise HTTPException(status_code=500, detail="Internal server error")
 
     @app.post("/api/content/{path:path}", status_code=201)
-    async def create_content(path: str, data: ContentCreate):
+    async def create_content(path: str, data: ContentCreate, response: Response):
         """Create a new content file. Returns 409 if file already exists."""
+        fs = _fs()
         try:
-            if filesystem.file_exists(path):
+            if fs.file_exists(path):
                 raise HTTPException(
                     status_code=409,
                     detail=f"File '{path}' already exists. Use PUT to update.",
                 )
-            filesystem.write_file(path, data.content)
+            fs.write_file(path, data.content)
             emit(CONTENT_CREATED, path)
+            try:
+                response.headers["ETag"] = _quoted(_etag(path))
+            except Exception:
+                pass
             return {"message": f"File '{path}' created successfully", "path": path}
         except HTTPException:
             raise
@@ -263,13 +356,49 @@ def create_api(
             raise HTTPException(status_code=500, detail="Internal server error")
 
     @app.put("/api/content/{path:path}")
-    async def update_content(path: str, data: ContentCreate):
-        """Update an existing content file (also allows creation)."""
+    async def update_content(
+        path: str,
+        data: ContentCreate,
+        request: Request,
+        response: Response,
+    ):
+        """Update an existing content file (also allows creation).
+
+        Honours ``If-Match`` for optimistic concurrency: 412 when the
+        precondition fails.
+        """
+        fs = _fs()
         try:
-            is_new = not filesystem.file_exists(path)
-            filesystem.write_file(path, data.content)
+            if_match = request.headers.get("if-match")
+            exists = fs.file_exists(path)
+            if if_match is not None:
+                if not exists:
+                    # No current representation to match against.
+                    raise HTTPException(
+                        status_code=412, detail="File does not exist"
+                    )
+                current_etag = _etag(path)
+                if not _if_match_matches(if_match, current_etag):
+                    return Response(
+                        status_code=412,
+                        content=(
+                            '{"detail":"ETag mismatch","current_etag":"'
+                            + current_etag
+                            + '"}'
+                        ),
+                        media_type="application/json",
+                        headers={"ETag": _quoted(current_etag)},
+                    )
+            is_new = not exists
+            fs.write_file(path, data.content)
             emit(CONTENT_CREATED if is_new else CONTENT_UPDATED, path)
+            try:
+                response.headers["ETag"] = _quoted(_etag(path))
+            except Exception:
+                pass
             return {"message": f"File '{path}' saved successfully", "path": path}
+        except HTTPException:
+            raise
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -279,8 +408,9 @@ def create_api(
     @app.delete("/api/content/{path:path}")
     async def delete_content(path: str):
         """Delete content file."""
+        fs = _fs()
         try:
-            filesystem.delete_file(path)
+            fs.delete_file(path)
             emit(CONTENT_DELETED, path)
             return {"message": f"File '{path}' deleted successfully", "path": path}
         except FileNotFoundError:
@@ -294,8 +424,9 @@ def create_api(
     @app.patch("/api/content/{path:path}")
     async def move_content(path: str, data: ContentMove):
         """Move or rename a content file."""
+        fs = _fs()
         try:
-            filesystem.move_file(path, data.destination)
+            fs.move_file(path, data.destination)
             emit(CONTENT_MOVED, data.destination, source_path=path)
             return {
                 "message": f"File moved from '{path}' to '{data.destination}'",
@@ -314,7 +445,7 @@ def create_api(
             logger.error(f"Error moving content: {e}")
             raise HTTPException(status_code=500, detail="Internal server error")
 
-    # --- Git endpoints (only when git backend is available) ---
+    # --- Git endpoints (only when git backend is available in legacy mode) ---
 
     if git_backend is not None:
 

--- a/stash_mcp/filesystem.py
+++ b/stash_mcp/filesystem.py
@@ -1,5 +1,6 @@
 """Filesystem layer for content management."""
 
+import hashlib
 import logging
 import re
 from pathlib import Path
@@ -289,6 +290,27 @@ class FileSystem:
         except Exception as e:
             logger.error(f"Error deleting file '{relative_path}': {e}")
             raise FileSystemError(f"Failed to delete file: {e}")
+
+    def content_hash(self, relative_path: str) -> str:
+        """Return the SHA-256 hex digest of a file's bytes.
+
+        Used as the ETag for non-git-tracked stores. Reads the file in
+        binary so the hash matches regardless of line-ending handling.
+
+        Raises:
+            FileNotFoundError: If file doesn't exist
+            InvalidPathError: If path is invalid or not a file
+        """
+        full_path = self._resolve_path(relative_path)
+        if not full_path.exists():
+            raise FileNotFoundError(f"File '{relative_path}' not found")
+        if not full_path.is_file():
+            raise InvalidPathError(f"Path '{relative_path}' is not a file")
+        h = hashlib.sha256()
+        with full_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
 
     def file_exists(self, relative_path: str) -> bool:
         """Check if a file exists.

--- a/stash_mcp/git_backend.py
+++ b/stash_mcp/git_backend.py
@@ -329,6 +329,31 @@ class GitBackend:
             )
         logger.debug("Renamed remote '%s' to '%s'", old_name, new_name)
 
+    def hash_object(self, path: str) -> str:
+        """Return the git blob SHA for *path*.
+
+        Used as the ETag for git-tracked stores. Uses
+        ``git hash-object`` so the hash matches what the blob would have
+        if it were committed — independent of whether the working-tree
+        file is currently tracked.
+
+        Args:
+            path: File path relative to the content directory.
+
+        Raises:
+            FileNotFoundError: If the working-tree file doesn't exist.
+            RuntimeError: If ``git hash-object`` fails for any other reason.
+        """
+        full_path = self.content_dir / path
+        if not full_path.exists():
+            raise FileNotFoundError(f"File '{path}' not found")
+        result = self._run(["git", "hash-object", "--", path])
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"git hash-object failed for {path!r}: {result.stderr.strip()}"
+            )
+        return result.stdout.strip()
+
     def blame(
         self,
         path: str,

--- a/stash_mcp/main.py
+++ b/stash_mcp/main.py
@@ -237,49 +237,107 @@ async def _git_sync_loop(
 
 
 def _create_auth_enabled_app() -> FastAPI:
-    """Minimal app scaffold for AUTH_ENABLED=True.
+    """Build the per-store routed app when ``AUTH_ENABLED=True``.
 
-    Routing into per-store ``/api/<tenant>/<store>/*`` and
-    ``/mcp/<tenant>/<store>/`` lives in spec 04. Until that lands, ``/api``
-    and ``/mcp`` return 503 so misconfigured deployments fail loudly
-    instead of silently serving the wrong content. The auth middleware
-    still runs, so the UI redirect-to-login flow from spec 02 keeps
-    working.
+    Mounts the MCP and REST handlers at ``/api`` and ``/mcp`` exactly as
+    in legacy mode; a :class:`StoreResolverMiddleware` rewrites
+    ``/api/<tenant>/<store>/*`` and ``/mcp/<tenant>/<store>/*`` to the
+    canonical paths and sets the per-request ``current_store``
+    contextvar. The MCP and API handlers read the store from that
+    contextvar via the :data:`USE_CURRENT_STORE` sentinel.
+
+    Search is disabled in auth mode for v1 — a single shared index
+    would leak content across tenants. See spec 04 open questions.
     """
-    # Touch the registry so it's instantiated and ready for 04 to consume.
-    get_store_registry()
+    from .api import USE_CURRENT_STORE as API_USE_CURRENT_STORE
+    from .mcp_server import USE_CURRENT_STORE as MCP_USE_CURRENT_STORE
+    from .routing import StoreResolverMiddleware
 
-    app = FastAPI()
+    registry = get_store_registry()
 
-    async def _not_wired() -> JSONResponse:
+    # Initialise metrics (auth mode shares the same opt-out behaviour).
+    init_metrics(
+        db_path=str(Config.METRICS_PATH),
+        enabled=Config.get_effective_metrics_enabled(),
+        retention_days=Config.METRICS_RETENTION_DAYS,
+    )
+
+    # Per-store routing means tools and REST handlers resolve their
+    # FileSystem at request time. No single search engine, no single
+    # git_backend at construction time.
+    mcp = create_mcp_server(MCP_USE_CURRENT_STORE)
+    mcp_http_app = mcp.http_app(path="/", stateless_http=Config.READ_ONLY)
+    mcp_lifespan = mcp_http_app.lifespan
+
+    @asynccontextmanager
+    async def _auth_lifespan(fastapi_app):
+        async with mcp_lifespan(fastapi_app):
+            get_metrics().record_server_event("startup")
+            yield
+            get_metrics().record_server_event("shutdown")
+            get_metrics().close()
+
+    app = create_api(API_USE_CURRENT_STORE, lifespan=_auth_lifespan)
+
+    # Search endpoint shim: explicit 503 when a client asks for search
+    # under auth mode, so it surfaces clearly rather than 404-ing.
+    @app.get("/api/{tenant}/{store}/search")
+    async def _search_disabled(tenant: str, store: str):
         return JSONResponse(
             {
                 "error": "service_unavailable",
                 "detail": (
-                    "STASH_AUTH_ENABLED=true: per-store routing has not been "
-                    "wired in this build. See docs/auth/04-routing.md."
+                    "Semantic search is disabled when STASH_AUTH_ENABLED=true "
+                    "(would leak content across tenants)."
                 ),
             },
             status_code=503,
         )
 
-    @app.get("/api/health")
-    async def _health() -> dict[str, str]:
-        return {"status": "ok"}
-
-    _methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
-    app.add_api_route("/api/{path:path}", _not_wired, methods=_methods)
-    app.add_api_route("/mcp", _not_wired, methods=_methods)
-    app.add_api_route("/mcp/{path:path}", _not_wired, methods=_methods)
-
     static_dir = Path(__file__).parent / "static"
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    # Mount MCP under /mcp — the resolver rewrites /mcp/<tenant>/<store>/...
+    # to /mcp/... before this subapp sees the request.
+    app.mount("/mcp", mcp_http_app)
+
+    # Normalize /mcp → /mcp/ to avoid 307 redirects (Cloudflare etc. drop
+    # request bodies on redirect).
+    class _MCPSlashMiddleware:
+        def __init__(self, app: ASGIApp) -> None:
+            self.app = app
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+            if scope["type"] == "http" and scope["path"] == "/mcp":
+                scope = dict(scope)
+                scope["path"] = "/mcp/"
+            await self.app(scope, receive, send)
 
     auth_providers = [
         SessionCookieAuthProvider(),
         ApiTokenAuthProvider(),
         OIDCAuthProvider(),
     ]
+
+    # Order matters: add_middleware adds outermost first, so execution
+    # is last-added-runs-first. We want auth → store resolver → app.
+    # Therefore add the slash normalizer first, then store resolver,
+    # then auth.
+    app.add_middleware(_MCPSlashMiddleware)
+    app.add_middleware(
+        StoreResolverMiddleware,
+        registry=registry,
+        public_prefixes=(
+            "/api/health",
+            "/auth",
+            "/admin",
+            "/ui",
+            "/static",
+            "/docs",
+            "/redoc",
+            "/openapi.json",
+        ),
+    )
     app.add_middleware(StashAuthMiddleware, providers=auth_providers)
     return app
 

--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -181,22 +181,64 @@ def parse_markdown_structure(content: str) -> list[dict]:
     return _build_heading_tree(flat_headings)
 
 
-def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=None) -> FastMCP:
+USE_CURRENT_STORE = object()
+"""Sentinel passed to :func:`create_mcp_server` in auth mode — tool
+bodies then resolve the FS / git_backend from
+:func:`stash_mcp.routing.context.current_store` at call time."""
+
+
+def create_mcp_server(
+    filesystem_or_resolver,
+    search_engine=None,
+    git_backend=None,
+) -> FastMCP:
     """Create and configure the FastMCP server.
 
     Args:
-        filesystem: Filesystem instance for content management
+        filesystem_or_resolver: Either a :class:`FileSystem` (legacy
+            single-store mode) or the :data:`USE_CURRENT_STORE` sentinel
+            (auth mode, where tool bodies resolve the FS from
+            :func:`current_store` at call time).
         search_engine: Optional SearchEngine instance for semantic search
-        git_backend: Optional GitBackend instance for git tools
+        git_backend: Optional GitBackend instance for git tools (legacy mode)
 
     Returns:
         Configured FastMCP server
     """
 
+    _auth_mode = filesystem_or_resolver is USE_CURRENT_STORE
+
+    def _fs():
+        """Resolve the FileSystem (or TransactionManager) for the in-flight call."""
+        if _auth_mode:
+            from .routing.context import require_store
+
+            return require_store().fs_for_mcp
+        return filesystem_or_resolver
+
+    def _bare_fs():
+        """Resolve the bare FileSystem for path checks."""
+        if _auth_mode:
+            from .routing.context import require_store
+
+            return require_store().filesystem
+        return filesystem_or_resolver
+
+    def _git_backend():
+        """Resolve the git backend for the in-flight call, if any."""
+        if _auth_mode:
+            from .routing.context import current_store
+
+            store = current_store()
+            return store.git_backend if store is not None else None
+        return git_backend
+
     @asynccontextmanager
     async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
         """Lifespan handler to inject filesystem into context."""
-        yield {"fs": filesystem}
+        # In auth mode the FS is per-store; tool bodies resolve it via
+        # current_store() — nothing useful to put here.
+        yield {"fs": None if _auth_mode else filesystem_or_resolver}
 
     mcp = FastMCP(
         name=Config.SERVER_NAME,
@@ -243,23 +285,27 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
 
     # Register only README.md files as resources (for resources/list).
     # All other files are accessible via tools and the resource template.
-    for file_path in filesystem.list_all_files():
-        if not _is_resource_file(file_path):
-            continue
-        uri = f"stash://{file_path}"
-        mime = _get_mime_type(file_path)
-        desc = _get_description(filesystem, file_path)
-        fp = file_path  # capture for closure
+    # In auth mode there's no single store to enumerate; the resource
+    # template below still works for ad-hoc reads, and 06's UI/SPA
+    # picker will own per-store resource registration.
+    if not _auth_mode:
+        for file_path in filesystem_or_resolver.list_all_files():
+            if not _is_resource_file(file_path):
+                continue
+            uri = f"stash://{file_path}"
+            mime = _get_mime_type(file_path)
+            desc = _get_description(filesystem_or_resolver, file_path)
+            fp = file_path  # capture for closure
 
-        mcp.add_resource(
-            FunctionResource(
-                uri=AnyUrl(uri),
-                name=file_path,
-                description=desc,
-                mime_type=mime,
-                fn=lambda _fp=fp: filesystem.read_file(_fp),
+            mcp.add_resource(
+                FunctionResource(
+                    uri=AnyUrl(uri),
+                    name=file_path,
+                    description=desc,
+                    mime_type=mime,
+                    fn=lambda _fp=fp: filesystem_or_resolver.read_file(_fp),
+                )
             )
-        )
 
     def _register_resource(path: str) -> bool:
         """Add a file to the MCP resource registry if it is a README.md.
@@ -269,12 +315,15 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
         """
         if not _is_resource_file(path):
             return False
+        if _auth_mode:
+            # Per-store resource registration is owned by 06's SPA picker.
+            return False
         uri = f"stash://{path}"
         mcp.add_resource(FunctionResource(
             uri=AnyUrl(uri), name=path,
-            description=_get_description(filesystem, path),
+            description=_get_description(filesystem_or_resolver, path),
             mime_type=_get_mime_type(path),
-            fn=lambda _fp=path: filesystem.read_file(_fp),
+            fn=lambda _fp=path: filesystem_or_resolver.read_file(_fp),
         ))
         return True
 
@@ -302,7 +351,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
     def read_resource(path: str) -> str:
         """Read a file by its path."""
         try:
-            return filesystem.read_file(path)
+            return _fs().read_file(path)
         except FileNotFoundError:
             raise ValueError(f"Resource not found: stash://{path}")
         except InvalidPathError as e:
@@ -334,11 +383,11 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 path: File path relative to content root
                 content: File content
             """
-            if filesystem.file_exists(path):
+            if _fs().file_exists(path):
                 raise ValueError(
                     f"File already exists: {path}. Use update_content to modify existing files."
                 )
-            filesystem.write_file(path, content)
+            _fs().write_file(path, content)
             if _register_resource(path):
                 await ctx.send_resource_list_changed()
             emit(CONTENT_CREATED, path)
@@ -368,8 +417,8 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 content: New file content
                 sha: SHA-256 hex digest of the current file content (from read_content)
             """
-            if filesystem.file_exists(path):
-                current = filesystem.read_file(path)
+            if _fs().file_exists(path):
+                current = _fs().read_file(path)
                 current_sha = hashlib.sha256(current.encode("utf-8")).hexdigest()
                 if sha != current_sha:
                     raise ValueError(
@@ -380,7 +429,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 raise FileNotFoundError(
                     f"File '{path}' does not exist. Use create_content for new files."
                 )
-            filesystem.write_file(path, content)
+            _fs().write_file(path, content)
             if _is_resource_file(path):
                 uri = AnyUrl(f"stash://{path}")
                 await ctx.session.send_resource_updated(uri=uri)
@@ -416,7 +465,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             Returns:
                 A dict with path, result status, and new_sha
             """
-            current = filesystem.read_file(file_path)
+            current = _fs().read_file(file_path)
             current_sha = hashlib.sha256(current.encode("utf-8")).hexdigest()
             if sha != current_sha:
                 raise ValueError(
@@ -424,7 +473,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                     "The file may have changed since it was last read."
                 )
             new_content = _apply_edits(current, edits, file_path)
-            filesystem.write_file(file_path, new_content)
+            _fs().write_file(file_path, new_content)
             if _is_resource_file(file_path):
                 uri = AnyUrl(f"stash://{file_path}")
                 await ctx.session.send_resource_updated(uri=uri)
@@ -465,7 +514,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             # Phase 1: read all files and validate SHAs
             originals: dict[str, str] = {}
             for op in edit_operations:
-                current = filesystem.read_file(op.file_path)
+                current = _fs().read_file(op.file_path)
                 current_sha = hashlib.sha256(current.encode("utf-8")).hexdigest()
                 if op.sha != current_sha:
                     raise ValueError(
@@ -482,7 +531,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             # Phase 3: write all files and send notifications
             results = []
             for op in edit_operations:
-                filesystem.write_file(op.file_path, new_contents[op.file_path])
+                _fs().write_file(op.file_path, new_contents[op.file_path])
                 if _is_resource_file(op.file_path):
                     uri = AnyUrl(f"stash://{op.file_path}")
                     await ctx.session.send_resource_updated(uri=uri)
@@ -515,14 +564,14 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             Returns:
                 Confirmation message
             """
-            current = filesystem.read_file(path)
+            current = _fs().read_file(path)
             current_sha = hashlib.sha256(current.encode("utf-8")).hexdigest()
             if sha != current_sha:
                 raise ValueError(
                     f"SHA mismatch for '{path}': expected {current_sha}, got {sha}. "
                     "The file may have changed since it was last read."
                 )
-            filesystem.delete_file(path)
+            _fs().delete_file(path)
             if _unregister_resource(path):
                 await ctx.send_resource_list_changed()
             emit(CONTENT_DELETED, path)
@@ -554,7 +603,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             A dict with 'content' (file text), 'sha' (SHA-256 hex digest of
             the FULL file), and 'truncated' (bool)
         """
-        content = await asyncio.to_thread(filesystem.read_file, path)
+        content = await asyncio.to_thread(_fs().read_file, path)
         sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
         truncated = False
         if max_lines is not None:
@@ -602,7 +651,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
         results = []
         for path in paths:
             try:
-                content = await asyncio.to_thread(filesystem.read_file, path)
+                content = await asyncio.to_thread(_fs().read_file, path)
                 sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
                 truncated = False
                 if max_lines is not None:
@@ -641,12 +690,12 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             A formatted string listing the files and directories
         """
         if recursive:
-            files = filesystem.list_all_files(path)
+            files = _fs().list_all_files(path)
             if not files:
                 return f"No files found under '{path or '/'}'"
             return "\n".join(files)
         else:
-            items = filesystem.list_files(path)
+            items = _fs().list_files(path)
             lines = []
             for name, is_dir in items:
                 prefix = "📁 " if is_dir else "📄 "
@@ -682,7 +731,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             raise ValueError(
                 f"inspect_content_structure only supports markdown files (.md, .markdown). Got: {path}"
             )
-        content = filesystem.read_file(path)
+        content = _fs().read_file(path)
         sections = parse_markdown_structure(content)
         title = None
         for heading in sections:
@@ -729,7 +778,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                         f"inspect_content_structure only supports markdown files "
                         f"(.md, .markdown). Got: {path}"
                     )
-                content = filesystem.read_file(path)
+                content = _fs().read_file(path)
                 sections = parse_markdown_structure(content)
                 title = None
                 for s in sections:
@@ -774,7 +823,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             Returns:
                 Confirmation message
             """
-            filesystem.move_file(source_path, dest_path)
+            _fs().move_file(source_path, dest_path)
             source_was_resource = _unregister_resource(source_path)
             dest_is_resource = _register_resource(dest_path)
             if source_was_resource or dest_is_resource:
@@ -807,7 +856,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             Returns:
                 A dict with 'source', 'destination', and 'files_moved' count
             """
-            moved_files = filesystem.move_directory(source_path, dest_path)
+            moved_files = _fs().move_directory(source_path, dest_path)
 
             # Handle resource registration changes for any README.md files
             resources_changed = False
@@ -875,9 +924,9 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 )
 
             for m in moves:
-                if not filesystem.file_exists(m.source_path):
+                if not _fs().file_exists(m.source_path):
                     raise ValueError(f"Source file not found: {m.source_path}")
-                dst = filesystem._resolve_path(m.dest_path)
+                dst = _bare_fs()._resolve_path(m.dest_path)
                 if dst.exists():
                     raise ValueError(f"Destination already exists: {m.dest_path}")
 
@@ -885,7 +934,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             resources_changed = False
 
             for m in moves:
-                filesystem.move_file(m.source_path, m.dest_path)
+                _fs().move_file(m.source_path, m.dest_path)
                 if _unregister_resource(m.source_path):
                     resources_changed = True
                 if _register_resource(m.dest_path):
@@ -966,8 +1015,19 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             return "\n".join(lines)
 
     # --- Git tools (registered only when GIT_TRACKING is enabled) ---
+    # In auth mode the per-store git_backend is resolved at call time;
+    # registration happens unconditionally so multi-store servers expose
+    # git tools regardless of which store the caller targets.
 
-    if git_backend is not None:
+    def _require_git_backend():
+        gb = _git_backend()
+        if gb is None:
+            raise ValueError(
+                "Git tracking is not enabled for this store."
+            )
+        return gb
+
+    if _auth_mode or git_backend is not None:
 
         @mcp.tool(
             annotations=ToolAnnotations(
@@ -990,7 +1050,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             """
             import asyncio
 
-            entries = await asyncio.to_thread(git_backend.log, path, max_count)
+            entries = await asyncio.to_thread(_require_git_backend().log, path, max_count)
             if not entries:
                 return f"No git history found for '{path}'."
             lines = []
@@ -1021,7 +1081,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             """
             import asyncio
 
-            return await asyncio.to_thread(git_backend.diff, path, ref)
+            return await asyncio.to_thread(_require_git_backend().diff, path, ref)
 
         @mcp.tool(
             annotations=ToolAnnotations(
@@ -1047,7 +1107,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             import asyncio
 
             blame_lines = await asyncio.to_thread(
-                git_backend.blame, path, start_line, end_line
+                _require_git_backend().blame, path, start_line, end_line
             )
             if not blame_lines:
                 return f"No blame data available for '{path}'."
@@ -1061,12 +1121,35 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
 
     # --- Transaction tools (only when write mode + git tracking are both active) ---
 
-    if not Config.READ_ONLY and git_backend is not None:
+    if not Config.READ_ONLY and (_auth_mode or git_backend is not None):
         from .transactions import TransactionError, TransactionManager
 
-        tm = filesystem if isinstance(filesystem, TransactionManager) else None
+        if _auth_mode:
+            def _resolve_tm():
+                from .routing.context import require_store
 
-        if tm is not None:
+                store_tm = require_store().transaction_manager
+                if store_tm is None:
+                    raise ValueError(
+                        "Transactions are not available for this store "
+                        "(no git tracking)."
+                    )
+                return store_tm
+
+            _have_tm = True
+        else:
+            _legacy_tm = (
+                filesystem_or_resolver
+                if isinstance(filesystem_or_resolver, TransactionManager)
+                else None
+            )
+
+            def _resolve_tm():
+                return _legacy_tm
+
+            _have_tm = _legacy_tm is not None
+
+        if _have_tm:
 
             @mcp.tool(
                 annotations=ToolAnnotations(
@@ -1091,7 +1174,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 """
                 session_id = str(id(ctx.session))
                 try:
-                    txn_id = await tm.start_transaction(
+                    txn_id = await _resolve_tm().start_transaction(
                         session_id,
                         Config.TRANSACTION_TIMEOUT,
                         Config.TRANSACTION_LOCK_WAIT,
@@ -1130,7 +1213,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 sync_remote = Config.GIT_SYNC_REMOTE if Config.GIT_SYNC_ENABLED else None
                 sync_branch = Config.GIT_SYNC_BRANCH if Config.GIT_SYNC_ENABLED else None
                 try:
-                    await tm.end_transaction(
+                    await _resolve_tm().end_transaction(
                         session_id, message, author, sync_remote, sync_branch
                     )
                 except TransactionError as exc:
@@ -1157,7 +1240,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 """
                 session_id = str(id(ctx.session))
                 try:
-                    await tm.abort_transaction(session_id)
+                    await _resolve_tm().abort_transaction(session_id)
                 except TransactionError as exc:
                     raise ValueError(str(exc))
                 return "Transaction aborted."
@@ -1183,6 +1266,6 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                     transaction details.
                 """
                 session_id = str(id(ctx.session))
-                return tm.get_transaction_status(session_id)
+                return _resolve_tm().get_transaction_status(session_id)
 
     return mcp

--- a/stash_mcp/routing/__init__.py
+++ b/stash_mcp/routing/__init__.py
@@ -1,0 +1,17 @@
+"""Per-store routing — middleware and contextvar for ``/api/<tenant>/<store>``."""
+
+from .context import (
+    current_store,
+    require_store,
+    reset_current_store,
+    set_current_store,
+)
+from .store_resolver import StoreResolverMiddleware
+
+__all__ = [
+    "StoreResolverMiddleware",
+    "current_store",
+    "require_store",
+    "reset_current_store",
+    "set_current_store",
+]

--- a/stash_mcp/routing/context.py
+++ b/stash_mcp/routing/context.py
@@ -1,0 +1,53 @@
+"""ContextVar plumbing for the in-flight ``LoadedStore``.
+
+Mirrors the ``current_principal`` pattern from spec 02. The
+:class:`StoreResolverMiddleware` sets the store at the top of the
+request and resets it in a ``finally`` block. Downstream code (REST
+handlers, MCP tool bodies, the UI) reads it via :func:`current_store` /
+:func:`require_store`.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+
+from ..stores.registry import LoadedStore
+
+_current_store: ContextVar[LoadedStore | None] = ContextVar(
+    "stash_current_store", default=None
+)
+
+
+def set_current_store(s: LoadedStore | None) -> Token:
+    """Set the contextvar and return a ``Token``.
+
+    Caller MUST pass the returned token to :func:`reset_current_store` in
+    a ``finally`` block — using ``.reset()`` (not ``.set(None)``) properly
+    restores the prior value, which matters for nested contexts and asyncio
+    task groups.
+    """
+    return _current_store.set(s)
+
+
+def reset_current_store(token: Token) -> None:
+    _current_store.reset(token)
+
+
+def current_store() -> LoadedStore | None:
+    """Return the store for the in-flight request, or ``None`` if no
+    resolver has run (e.g. ``AUTH_ENABLED=False``)."""
+    return _current_store.get()
+
+
+def require_store() -> LoadedStore:
+    """Return the in-flight store or raise ``RuntimeError``.
+
+    Programmer-error sentinel: by the time a handler runs the resolver
+    should already have set this. Not a 401/403.
+    """
+    s = _current_store.get()
+    if s is None:
+        raise RuntimeError(
+            "no store in scope — route was reached without resolver"
+        )
+    return s

--- a/stash_mcp/routing/store_resolver.py
+++ b/stash_mcp/routing/store_resolver.py
@@ -1,0 +1,157 @@
+"""ASGI middleware that resolves ``/api/<tenant>/<store>`` and
+``/mcp/<tenant>/<store>`` to a :class:`LoadedStore`, sets the
+``current_store`` contextvar, and rewrites the path so the mounted
+subapp sees the same routes it always has.
+
+Sits *after* :class:`StashAuthMiddleware` in the stack so it can read
+``current_principal()``. When ``AUTH_ENABLED=False`` the middleware
+no-ops.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from ..auth.context import current_principal
+from ..config import Config
+from ..stores.registry import StoreNotProvisionedError, StoreRegistry
+from .context import reset_current_store, set_current_store
+
+logger = logging.getLogger(__name__)
+
+_SLUG = r"[a-z0-9][a-z0-9-]{0,62}"
+_API_RE = re.compile(rf"^/api/(?P<tenant>{_SLUG})/(?P<store>{_SLUG})(?P<rest>/.*)?$")
+_MCP_RE = re.compile(rf"^/mcp/(?P<tenant>{_SLUG})/(?P<store>{_SLUG})(?P<rest>/.*)?$")
+
+
+async def _send_json(send: Send, status: int, body: dict) -> None:
+    payload = json.dumps(body).encode("utf-8")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(payload)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": payload, "more_body": False})
+
+
+class StoreResolverMiddleware:
+    """Resolve ``/api/<tenant>/<store>`` and ``/mcp/<tenant>/<store>``.
+
+    Args:
+        app: Next ASGI app in the chain.
+        registry: Process-wide :class:`StoreRegistry`.
+        public_prefixes: Path prefixes that bypass the resolver entirely
+            (health, auth, admin, ui, static, openapi).
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        registry: StoreRegistry,
+        public_prefixes: tuple[str, ...] = (),
+    ) -> None:
+        self.app = app
+        self.registry = registry
+        self.public_prefixes = public_prefixes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not Config.AUTH_ENABLED:
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope["path"]
+
+        # Pass-through for paths that don't carry a tenant+store.
+        if any(path == p or path.startswith(p) for p in self.public_prefixes):
+            await self.app(scope, receive, send)
+            return
+
+        is_api = path == "/api" or path.startswith("/api/")
+        is_mcp = path == "/mcp" or path.startswith("/mcp/")
+        if not (is_api or is_mcp):
+            await self.app(scope, receive, send)
+            return
+
+        m = _API_RE.match(path) or _MCP_RE.match(path)
+        if m is None:
+            await _send_json(
+                send,
+                404,
+                {
+                    "error": "not_found",
+                    "detail": (
+                        "expected /api/<tenant>/<store>/... or /mcp/<tenant>/<store>/..."
+                    ),
+                },
+            )
+            return
+
+        principal = current_principal()
+        if principal is None:
+            # Defensive — the auth middleware should have rejected first.
+            await _send_json(
+                send, 401, {"error": "unauthenticated"}
+            )
+            return
+
+        tenant_slug = m.group("tenant")
+        store_slug = m.group("store")
+        try:
+            loaded = await self.registry.get(tenant_slug, store_slug)
+        except KeyError:
+            await _send_json(
+                send,
+                404,
+                {
+                    "error": "not_found",
+                    "detail": f"store {tenant_slug}/{store_slug} not found",
+                },
+            )
+            return
+        except StoreNotProvisionedError as exc:
+            logger.error("Store %s/%s not provisioned: %s", tenant_slug, store_slug, exc)
+            await _send_json(
+                send,
+                500,
+                {
+                    "error": "store_not_provisioned",
+                    "detail": str(exc),
+                },
+            )
+            return
+
+        if not principal.has_role_on(loaded.tenant_id, "member"):
+            # 403 — principal is authenticated but not a member of the
+            # URL's tenant. Don't leak whether the store exists.
+            await _send_json(
+                send,
+                403,
+                {
+                    "error": "forbidden",
+                    "detail": f"not a member of tenant {tenant_slug}",
+                },
+            )
+            return
+
+        # Rewrite the path so the subapp sees /api/<rest> or /mcp/<rest>.
+        prefix = "/api" if is_api else "/mcp"
+        rest = m.group("rest") or "/"
+        new_path = prefix + rest
+        new_scope = dict(scope)
+        new_scope["path"] = new_path
+        new_scope["raw_path"] = new_path.encode("utf-8")
+
+        token = set_current_store(loaded)
+        try:
+            await self.app(new_scope, receive, send)
+        finally:
+            reset_current_store(token)

--- a/tests/routing/conftest.py
+++ b/tests/routing/conftest.py
@@ -1,0 +1,79 @@
+"""Fixtures for the routing test suite.
+
+Stands up the same in-memory SQLite + sessionmaker monkey-patching as
+``tests/auth/conftest.py`` and ``tests/stores/test_registry.py``, plus a
+content_dir under ``tmp_path`` so the registry can find on-disk repos.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from stash_mcp.config import Config
+from stash_mcp.db import engine as engine_mod
+from stash_mcp.db import session as session_mod
+from stash_mcp.db.models import Base
+from stash_mcp.stores import registry as registry_mod
+
+
+def _enable_sqlite_fks(engine: AsyncEngine) -> None:
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_pragma(dbapi_connection, _record):  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+@pytest.fixture
+async def auth_db(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[
+    async_sessionmaker[AsyncSession]
+]:
+    test_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    _enable_sqlite_fks(test_engine)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    test_sessionmaker = async_sessionmaker(
+        test_engine, expire_on_commit=False, class_=AsyncSession
+    )
+    monkeypatch.setattr(engine_mod, "_engine", test_engine, raising=False)
+    monkeypatch.setattr(session_mod, "_sessionmaker", test_sessionmaker, raising=False)
+    try:
+        yield test_sessionmaker
+    finally:
+        await test_engine.dispose()
+        monkeypatch.setattr(engine_mod, "_engine", None, raising=False)
+        monkeypatch.setattr(session_mod, "_sessionmaker", None, raising=False)
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    monkeypatch.setattr(Config, "READ_ONLY", False, raising=False)
+    monkeypatch.setattr(Config, "AUTH_ENABLED", True, raising=False)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_singleton(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+    yield
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)

--- a/tests/routing/test_per_store_api.py
+++ b/tests/routing/test_per_store_api.py
@@ -1,0 +1,314 @@
+"""Per-store REST API tests — isolation + ETag conditional requests.
+
+Builds an auth-enabled FastAPI app on top of a temp content dir and an
+in-memory DB, drives it through ``TestClient`` with a fake auth
+middleware that injects a principal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.testclient import TestClient
+
+from stash_mcp.api import USE_CURRENT_STORE, create_api
+from stash_mcp.auth.context import (
+    reset_current_principal,
+    set_current_principal,
+)
+from stash_mcp.auth.principal import Principal
+from stash_mcp.db.models import Store, Tenant
+from stash_mcp.git_backend import GitBackend
+from stash_mcp.routing import StoreResolverMiddleware
+from stash_mcp.stores.registry import StoreRegistry
+
+
+async def _make_tenant_and_store(
+    sm: async_sessionmaker[AsyncSession],
+    *,
+    tenant_slug: str,
+    store_slug: str,
+) -> tuple[Tenant, Store]:
+    async with sm() as session:
+        tenant = Tenant(slug=tenant_slug, display_name=tenant_slug.title())
+        session.add(tenant)
+        await session.flush()
+        store = Store(
+            tenant_id=tenant.id,
+            slug=store_slug,
+            display_name=store_slug.title(),
+            git_branch="main",
+        )
+        session.add(store)
+        await session.commit()
+        await session.refresh(tenant)
+        await session.refresh(store)
+        return tenant, store
+
+
+def _principal(tenant_ids: list[UUID]) -> Principal:
+    from uuid import uuid4
+
+    return Principal(
+        user_id=uuid4(),
+        oidc_sub="sub-test",
+        email="test@example.com",
+        display_name="Test",
+        auth_method="api_token",
+        tenant_roles={tid: "member" for tid in tenant_ids},
+    )
+
+
+def _principal_setter(principal: Principal):
+    class _Middleware:
+        def __init__(self, inner):
+            self.inner = inner
+
+        async def __call__(self, scope, receive, send):
+            if scope["type"] != "http":
+                await self.inner(scope, receive, send)
+                return
+            token = set_current_principal(principal)
+            try:
+                await self.inner(scope, receive, send)
+            finally:
+                reset_current_principal(token)
+
+    return _Middleware
+
+
+def _build_app(registry: StoreRegistry, principal: Principal):
+    api = create_api(USE_CURRENT_STORE)
+    resolver = StoreResolverMiddleware(
+        api,
+        registry=registry,
+        public_prefixes=("/api/health",),
+    )
+    return _principal_setter(principal)(resolver)
+
+
+@pytest.fixture
+async def two_stores(auth_db, content_dir: Path) -> tuple[Tenant, Tenant]:
+    tenant_a, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    tenant_b, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="other", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant_a.id) / "docs")
+    GitBackend.init(content_dir / str(tenant_b.id) / "docs")
+    return tenant_a, tenant_b
+
+
+async def test_store_isolation_create_in_a_404_in_b(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, tenant_b = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id, tenant_b.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    # Write to store A
+    resp = client.post(
+        "/api/acme/docs/content/hello.md", json={"content": "from A"}
+    )
+    assert resp.status_code == 201
+
+    # Reading from store B should 404 — different repo
+    resp = client.get("/api/other/docs/content/hello.md")
+    assert resp.status_code == 404
+
+    # Reading from store A returns the content
+    resp = client.get("/api/acme/docs/content/hello.md")
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "from A"
+
+
+async def test_list_reflects_only_one_store(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, tenant_b = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id, tenant_b.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/a-only.md", json={"content": "A"})
+    client.post("/api/other/docs/content/b-only.md", json={"content": "B"})
+
+    resp = client.get("/api/acme/docs/content?recursive=true")
+    paths_a = [item["path"] for item in resp.json()["items"]]
+    assert "a-only.md" in paths_a
+    assert "b-only.md" not in paths_a
+
+    resp = client.get("/api/other/docs/content?recursive=true")
+    paths_b = [item["path"] for item in resp.json()["items"]]
+    assert "b-only.md" in paths_b
+    assert "a-only.md" not in paths_b
+
+
+async def test_delete_in_a_doesnt_affect_b(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, tenant_b = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id, tenant_b.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/shared-name.md", json={"content": "A"})
+    client.post("/api/other/docs/content/shared-name.md", json={"content": "B"})
+
+    resp = client.delete("/api/acme/docs/content/shared-name.md")
+    assert resp.status_code == 200
+
+    assert client.get("/api/acme/docs/content/shared-name.md").status_code == 404
+    assert client.get("/api/other/docs/content/shared-name.md").status_code == 200
+
+
+# --- ETag tests --------------------------------------------------------
+
+
+async def test_get_returns_etag_header(auth_db, content_dir: Path, two_stores):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/etag.md", json={"content": "hello"})
+    resp = client.get("/api/acme/docs/content/etag.md")
+    assert resp.status_code == 200
+    assert "etag" in {k.lower() for k in resp.headers}
+    etag = resp.headers["etag"]
+    assert etag.startswith('"') and etag.endswith('"')
+
+
+async def test_if_none_match_returns_304(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/etag.md", json={"content": "v1"})
+    first = client.get("/api/acme/docs/content/etag.md")
+    etag = first.headers["etag"]
+
+    resp = client.get(
+        "/api/acme/docs/content/etag.md",
+        headers={"If-None-Match": etag},
+    )
+    assert resp.status_code == 304
+    # 304 must keep the ETag and have empty body
+    assert resp.headers["etag"] == etag
+    assert resp.content == b""
+
+
+async def test_if_none_match_nonmatching_returns_200(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/etag.md", json={"content": "v1"})
+    resp = client.get(
+        "/api/acme/docs/content/etag.md",
+        headers={"If-None-Match": '"deadbeef"'},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "v1"
+
+
+async def test_put_with_matching_if_match_updates(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/etag.md", json={"content": "v1"})
+    first = client.get("/api/acme/docs/content/etag.md")
+    etag = first.headers["etag"]
+
+    resp = client.put(
+        "/api/acme/docs/content/etag.md",
+        json={"content": "v2"},
+        headers={"If-Match": etag},
+    )
+    assert resp.status_code == 200
+    new_etag = resp.headers.get("etag")
+    assert new_etag is not None and new_etag != etag
+
+    confirmed = client.get("/api/acme/docs/content/etag.md")
+    assert confirmed.json()["content"] == "v2"
+    assert confirmed.headers["etag"] == new_etag
+
+
+async def test_put_with_nonmatching_if_match_returns_412(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/etag.md", json={"content": "v1"})
+    first = client.get("/api/acme/docs/content/etag.md")
+    current_etag = first.headers["etag"]
+
+    resp = client.put(
+        "/api/acme/docs/content/etag.md",
+        json={"content": "v2"},
+        headers={"If-Match": '"stale-etag"'},
+    )
+    assert resp.status_code == 412
+    # The response carries the current ETag so the client can retry.
+    assert resp.headers.get("etag") == current_etag
+    # And the file content was NOT changed.
+    confirmed = client.get("/api/acme/docs/content/etag.md")
+    assert confirmed.json()["content"] == "v1"
+
+
+async def test_put_without_if_match_writes_unconditionally(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    client.post("/api/acme/docs/content/etag.md", json={"content": "v1"})
+    resp = client.put(
+        "/api/acme/docs/content/etag.md", json={"content": "v2"}
+    )
+    assert resp.status_code == 200
+    confirmed = client.get("/api/acme/docs/content/etag.md")
+    assert confirmed.json()["content"] == "v2"
+
+
+async def test_health_works_without_tenant_or_auth(
+    auth_db, content_dir: Path, two_stores
+):
+    tenant_a, _ = two_stores
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id])
+    app = _build_app(registry, principal)
+    client = TestClient(app)
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"

--- a/tests/routing/test_per_store_mcp.py
+++ b/tests/routing/test_per_store_mcp.py
@@ -1,0 +1,225 @@
+"""Per-store MCP tool tests — call tools with current_store set to each
+store and confirm isolation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from stash_mcp.db.models import Store, Tenant
+from stash_mcp.git_backend import GitBackend
+from stash_mcp.mcp_server import USE_CURRENT_STORE, create_mcp_server
+from stash_mcp.routing.context import reset_current_store, set_current_store
+from stash_mcp.stores.registry import StoreRegistry
+
+
+@pytest.fixture
+def mock_context():
+    from fastmcp.server.context import Context, _current_context
+
+    ctx = MagicMock(spec=Context)
+    ctx.session = AsyncMock()
+    ctx.send_resource_list_changed = AsyncMock()
+    token = _current_context.set(ctx)
+    yield ctx
+    _current_context.reset(token)
+
+
+async def _make_tenant_and_store(
+    sm: async_sessionmaker[AsyncSession],
+    *,
+    tenant_slug: str,
+    store_slug: str,
+) -> tuple[Tenant, Store]:
+    async with sm() as session:
+        tenant = Tenant(slug=tenant_slug, display_name=tenant_slug.title())
+        session.add(tenant)
+        await session.flush()
+        store = Store(
+            tenant_id=tenant.id,
+            slug=store_slug,
+            display_name=store_slug.title(),
+            git_branch="main",
+        )
+        session.add(store)
+        await session.commit()
+        await session.refresh(tenant)
+        await session.refresh(store)
+        return tenant, store
+
+
+async def test_create_and_read_via_current_store(
+    auth_db, content_dir: Path, mock_context, monkeypatch: pytest.MonkeyPatch
+):
+    # Two provisioned stores.
+    tenant_a, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    tenant_b, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="other", store_slug="docs"
+    )
+    # No git so writes don't need a transaction.
+    (content_dir / str(tenant_a.id) / "docs").mkdir(parents=True)
+    (content_dir / str(tenant_b.id) / "docs").mkdir(parents=True)
+
+    registry = StoreRegistry()
+    store_a = await registry.get("acme", "docs")
+    store_b = await registry.get("other", "docs")
+
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    create = await mcp.get_tool("create_content")
+    read = await mcp.get_tool("read_content")
+    list_tool = await mcp.get_tool("list_content")
+
+    # Write into store A
+    token = set_current_store(store_a)
+    try:
+        await create.run({"path": "a-only.md", "content": "from A"})
+    finally:
+        reset_current_store(token)
+
+    # Read back from store A
+    token = set_current_store(store_a)
+    try:
+        result = await read.run({"path": "a-only.md"})
+    finally:
+        reset_current_store(token)
+    assert "from A" in str(result.content)
+
+    # Same path does not exist in store B
+    token = set_current_store(store_b)
+    try:
+        with pytest.raises(Exception):
+            await read.run({"path": "a-only.md"})
+    finally:
+        reset_current_store(token)
+
+    # list_content reflects each store's contents
+    token = set_current_store(store_a)
+    try:
+        a_listing = await list_tool.run({"path": "", "recursive": True})
+    finally:
+        reset_current_store(token)
+    assert "a-only.md" in str(a_listing.content)
+
+    token = set_current_store(store_b)
+    try:
+        b_listing = await list_tool.run({"path": "", "recursive": True})
+    finally:
+        reset_current_store(token)
+    assert "a-only.md" not in str(b_listing.content)
+
+
+async def test_tool_call_without_store_raises(
+    auth_db, content_dir: Path, mock_context
+):
+    """Tools resolve the store via ``require_store`` — calling them
+    without setting the contextvar is a programmer error."""
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    list_tool = await mcp.get_tool("list_content")
+    with pytest.raises(RuntimeError, match="no store in scope"):
+        await list_tool.run({"path": "", "recursive": False})
+
+
+async def test_git_tools_registered_in_auth_mode(
+    auth_db, content_dir: Path
+):
+    """Git tools are registered unconditionally in auth mode so that
+    multi-store servers expose them regardless of the active store."""
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    tools = await mcp.get_tools()
+    assert "log_content" in tools
+    assert "diff_content" in tools
+    assert "blame_content" in tools
+
+
+async def test_git_tools_raise_when_store_has_no_git(
+    auth_db, content_dir: Path, mock_context
+):
+    tenant, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    (content_dir / str(tenant.id) / "docs").mkdir(parents=True)
+
+    registry = StoreRegistry()
+    store = await registry.get("acme", "docs")
+    assert store.git_backend is None
+
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    log_tool = await mcp.get_tool("log_content")
+
+    token = set_current_store(store)
+    try:
+        with pytest.raises(Exception, match="Git tracking is not enabled"):
+            await log_tool.run({"path": "anything", "max_count": 1})
+    finally:
+        reset_current_store(token)
+
+
+async def test_transaction_tools_raise_when_store_has_no_git(
+    auth_db, content_dir: Path, mock_context
+):
+    """Transaction tools are registered in auth mode but only succeed for
+    stores that have git tracking."""
+    tenant, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    (content_dir / str(tenant.id) / "docs").mkdir(parents=True)
+
+    registry = StoreRegistry()
+    store = await registry.get("acme", "docs")
+    assert store.transaction_manager is None
+
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    start = await mcp.get_tool("start_content_transaction")
+
+    token = set_current_store(store)
+    try:
+        with pytest.raises(Exception, match="Transactions are not available"):
+            await start.run({})
+    finally:
+        reset_current_store(token)
+
+
+async def test_git_tool_uses_per_store_backend(
+    auth_db, content_dir: Path, mock_context
+):
+    tenant_a, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    repo = content_dir / str(tenant_a.id) / "docs"
+    GitBackend.init(repo, author_default="test <t@x>")
+
+    # registry.get() runs GitBackend.validate() which sets local user
+    # config from author_default — needed before our commit below.
+    registry = StoreRegistry()
+    store_a = await registry.get("acme", "docs")
+
+    # Commit a file so log_content has something to return.
+    (repo / "file.md").write_text("hello")
+    import subprocess
+
+    subprocess.run(
+        ["git", "add", "file.md"], cwd=repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "-m", "init"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    assert store_a.git_backend is not None
+
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    log_tool = await mcp.get_tool("log_content")
+
+    token = set_current_store(store_a)
+    try:
+        result = await log_tool.run({"path": "file.md", "max_count": 5})
+    finally:
+        reset_current_store(token)
+    text = str(result.content)
+    assert "init" in text

--- a/tests/routing/test_store_resolver.py
+++ b/tests/routing/test_store_resolver.py
@@ -1,0 +1,410 @@
+"""StoreResolverMiddleware tests — path matching, ACL, contextvar lifetime."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from stash_mcp.auth.context import (
+    reset_current_principal,
+    set_current_principal,
+)
+from stash_mcp.auth.principal import Principal
+from stash_mcp.db.models import Store, Tenant
+from stash_mcp.git_backend import GitBackend
+from stash_mcp.routing import StoreResolverMiddleware
+from stash_mcp.routing.context import current_store
+from stash_mcp.stores.registry import StoreRegistry
+
+
+async def _make_tenant_and_store(
+    sm: async_sessionmaker[AsyncSession],
+    *,
+    tenant_slug: str,
+    store_slug: str,
+) -> tuple[Tenant, Store]:
+    async with sm() as session:
+        tenant = Tenant(slug=tenant_slug, display_name=tenant_slug.title())
+        session.add(tenant)
+        await session.flush()
+        store = Store(
+            tenant_id=tenant.id,
+            slug=store_slug,
+            display_name=store_slug.title(),
+            git_branch="main",
+        )
+        session.add(store)
+        await session.commit()
+        await session.refresh(tenant)
+        await session.refresh(store)
+        return tenant, store
+
+
+def _principal(tenant_ids: list[UUID]) -> Principal:
+    """Build a Principal with member membership on each given tenant_id."""
+    from uuid import uuid4
+
+    return Principal(
+        user_id=uuid4(),
+        oidc_sub="sub-test",
+        email="test@example.com",
+        display_name="Test",
+        auth_method="api_token",
+        tenant_roles={tid: "member" for tid in tenant_ids},
+    )
+
+
+def _inner_app(captured: dict):
+    """A Starlette app that records the rewritten path and current_store."""
+
+    async def echo(request: Request):
+        captured["path"] = request.url.path
+        captured["raw_path"] = request.scope.get("raw_path")
+        store = current_store()
+        captured["store_tenant_slug"] = store.tenant_slug if store else None
+        captured["store_slug"] = store.slug if hasattr(store, "slug") else (
+            store.store_slug if store else None
+        )
+        return JSONResponse({"ok": True})
+
+    return Starlette(
+        routes=[
+            Route("/api/{rest:path}", echo, methods=["GET", "POST"]),
+            Route("/mcp/{rest:path}", echo, methods=["GET", "POST"]),
+            Route("/api/health", echo, methods=["GET"]),
+            Route("/api", echo, methods=["GET", "POST"]),
+            Route("/mcp", echo, methods=["GET", "POST"]),
+            Route("/", echo, methods=["GET"]),
+        ]
+    )
+
+
+def _wrap_with_principal(app, principal: Principal | None):
+    """Install a thin middleware that sets ``current_principal`` ahead of
+    the StoreResolver. The real auth middleware does this in production."""
+
+    class _PrincipalSetter:
+        def __init__(self, inner):
+            self.inner = inner
+
+        async def __call__(self, scope, receive, send):
+            if scope["type"] != "http" or principal is None:
+                await self.inner(scope, receive, send)
+                return
+            token = set_current_principal(principal)
+            try:
+                await self.inner(scope, receive, send)
+            finally:
+                reset_current_principal(token)
+
+    return _PrincipalSetter(app)
+
+
+def _build_test_app(
+    inner_app, registry: StoreRegistry, principal: Principal | None
+):
+    resolver = StoreResolverMiddleware(
+        inner_app,
+        registry=registry,
+        public_prefixes=("/api/health", "/auth", "/admin", "/ui", "/static"),
+    )
+    return _wrap_with_principal(resolver, principal)
+
+
+@pytest.fixture
+def captured() -> dict:
+    return {}
+
+
+async def test_valid_api_path_rewrites_and_sets_store(
+    auth_db, content_dir: Path, captured: dict
+):
+    tenant, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, _principal([tenant.id]))
+
+    client = TestClient(app)
+    resp = client.get("/api/acme/docs/content")
+    assert resp.status_code == 200
+    assert captured["path"] == "/api/content"
+    assert captured["raw_path"] == b"/api/content"
+    assert captured["store_tenant_slug"] == "acme"
+    assert captured["store_slug"] == "docs"
+
+
+async def test_valid_mcp_path_rewrites(
+    auth_db, content_dir: Path, captured: dict
+):
+    tenant, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, _principal([tenant.id]))
+
+    client = TestClient(app)
+    resp = client.get("/mcp/acme/docs/")
+    assert resp.status_code == 200
+    assert captured["path"] == "/mcp/"
+
+
+async def test_malformed_tenant_slug_404s_before_db(
+    auth_db, content_dir: Path, captured: dict
+):
+    registry = StoreRegistry()
+    # If the resolver reaches the DB this lookup would also fail, but we
+    # want to prove it rejects the slug *before* a DB roundtrip.
+    call_count = {"n": 0}
+    real_get = registry.get
+
+    async def counting_get(t, s):
+        call_count["n"] += 1
+        return await real_get(t, s)
+
+    registry.get = counting_get  # type: ignore[assignment]
+
+    app = _build_test_app(
+        _inner_app(captured), registry, _principal([])
+    )
+    client = TestClient(app)
+    resp = client.get("/api/UPPER/docs/content")
+    assert resp.status_code == 404
+    assert call_count["n"] == 0
+
+
+async def test_malformed_store_slug_404s_before_db(
+    auth_db, content_dir: Path, captured: dict
+):
+    registry = StoreRegistry()
+    call_count = {"n": 0}
+    real_get = registry.get
+
+    async def counting_get(t, s):
+        call_count["n"] += 1
+        return await real_get(t, s)
+
+    registry.get = counting_get  # type: ignore[assignment]
+
+    app = _build_test_app(_inner_app(captured), registry, _principal([]))
+    client = TestClient(app)
+    resp = client.get("/api/acme/Bad_Store/content")
+    assert resp.status_code == 404
+    assert call_count["n"] == 0
+
+
+async def test_unknown_store_404(auth_db, content_dir: Path, captured: dict):
+    tenant, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, _principal([tenant.id]))
+    client = TestClient(app)
+    resp = client.get("/api/acme/ghost/content")
+    assert resp.status_code == 404
+
+
+async def test_unknown_tenant_404(auth_db, content_dir: Path, captured: dict):
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, _principal([]))
+    client = TestClient(app)
+    resp = client.get("/api/ghost/docs/content")
+    assert resp.status_code == 404
+
+
+async def test_principal_not_member_of_tenant_403(
+    auth_db, content_dir: Path, captured: dict
+):
+    """Regression for the cross-tenant access bug — principal has
+    membership on tenant A trying to reach a store under tenant B."""
+    tenant_a, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    tenant_b, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="other", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant_a.id) / "docs")
+    GitBackend.init(content_dir / str(tenant_b.id) / "docs")
+
+    registry = StoreRegistry()
+    # Principal has membership only on tenant_a.
+    app = _build_test_app(
+        _inner_app(captured), registry, _principal([tenant_a.id])
+    )
+    client = TestClient(app)
+    resp = client.get("/api/other/docs/content")
+    assert resp.status_code == 403
+
+
+async def test_multi_tenant_principal_succeeds_on_both(
+    auth_db, content_dir: Path, captured: dict
+):
+    tenant_a, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    tenant_b, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="other", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant_a.id) / "docs")
+    GitBackend.init(content_dir / str(tenant_b.id) / "docs")
+
+    registry = StoreRegistry()
+
+    # Membership order in the dict should not affect outcomes.
+    for order in ([tenant_a.id, tenant_b.id], [tenant_b.id, tenant_a.id]):
+        principal = _principal(order)
+        app = _build_test_app(_inner_app(captured), registry, principal)
+        client = TestClient(app)
+        assert client.get("/api/acme/docs/content").status_code == 200
+        assert captured["store_tenant_slug"] == "acme"
+        assert client.get("/api/other/docs/content").status_code == 200
+        assert captured["store_tenant_slug"] == "other"
+
+
+async def test_health_skipped_by_resolver(
+    auth_db, content_dir: Path, captured: dict
+):
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, None)
+    client = TestClient(app)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert captured["store_tenant_slug"] is None
+
+
+async def test_public_prefixes_skipped(
+    auth_db, content_dir: Path, captured: dict
+):
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, None)
+    client = TestClient(app)
+    # /auth, /admin, /ui, /static all bypass the resolver.
+    for path in ("/auth/login", "/admin/foo", "/ui/", "/static/x.css"):
+        # the inner app may 404 since those routes aren't defined, but
+        # the resolver should NOT intercept with its own 401/404.
+        resp = client.get(path)
+        assert resp.status_code in (200, 404)
+
+
+async def test_concurrent_requests_dont_leak_store(
+    auth_db, content_dir: Path
+):
+    tenant_a, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    tenant_b, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="other", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant_a.id) / "docs")
+    GitBackend.init(content_dir / str(tenant_b.id) / "docs")
+
+    registry = StoreRegistry()
+    principal = _principal([tenant_a.id, tenant_b.id])
+
+    seen_slugs: list[str] = []
+
+    async def echo(request: Request):
+        await asyncio.sleep(0.02)
+        s = current_store()
+        seen_slugs.append(f"{s.tenant_slug}/{s.store_slug}")
+        return JSONResponse({"slug": s.store_slug})
+
+    inner = Starlette(
+        routes=[Route("/api/{rest:path}", echo, methods=["GET"])]
+    )
+    app = _build_test_app(inner, registry, principal)
+
+    # Drive the ASGI app concurrently with two different store URLs.
+    async def call(path: str) -> int:
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "root_path": "",
+        }
+        status: dict = {}
+        sent = asyncio.Event()
+
+        async def receive():
+            await asyncio.Event().wait()  # never resolves; not needed for GET
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status["code"] = message["status"]
+            elif message["type"] == "http.response.body":
+                sent.set()
+
+        task = asyncio.create_task(app(scope, receive, send))
+        await sent.wait()
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, BaseException):
+            pass
+        return status["code"]
+
+    codes = await asyncio.gather(
+        call("/api/acme/docs/content"),
+        call("/api/other/docs/content"),
+    )
+    assert codes == [200, 200]
+    assert sorted(seen_slugs) == ["acme/docs", "other/docs"]
+    # After the responses, the contextvar must be back to its baseline.
+    assert current_store() is None
+
+
+async def test_missing_principal_401(
+    auth_db, content_dir: Path, captured: dict
+):
+    """Defensive 401 if the resolver is reached without a principal.
+    Production has the auth middleware in front, but this guards against
+    a misconfigured stack."""
+    tenant, _ = await _make_tenant_and_store(
+        auth_db, tenant_slug="acme", store_slug="docs"
+    )
+    GitBackend.init(content_dir / str(tenant.id) / "docs")
+
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, None)
+    client = TestClient(app)
+    resp = client.get("/api/acme/docs/content")
+    assert resp.status_code == 401
+
+
+async def test_auth_disabled_passes_through(
+    auth_db, content_dir: Path, captured: dict, monkeypatch: pytest.MonkeyPatch
+):
+    """When AUTH_ENABLED=False the resolver no-ops."""
+    from stash_mcp.config import Config
+
+    monkeypatch.setattr(Config, "AUTH_ENABLED", False, raising=False)
+    registry = StoreRegistry()
+    app = _build_test_app(_inner_app(captured), registry, None)
+    client = TestClient(app)
+    # Without auth the resolver leaves the path alone, hitting the inner
+    # /api/{rest:path} route directly.
+    resp = client.get("/api/content")
+    assert resp.status_code == 200
+    assert captured["path"] == "/api/content"
+    assert captured["store_tenant_slug"] is None


### PR DESCRIPTION
## Summary

Implement per-store routing for multi-tenant deployments when `AUTH_ENABLED=True`. Requests to `/api/<tenant>/<store>/*` and `/mcp/<tenant>/<store>/*` are now resolved to the correct store, with the store set in a contextvar that downstream handlers read from. This enables the same REST API and MCP server code to serve multiple isolated stores without modification.

## Key Changes

- **StoreResolverMiddleware** (`stash_mcp/routing/store_resolver.py`): New ASGI middleware that:
  - Matches `/api/<tenant>/<store>` and `/mcp/<tenant>/<store>` paths using slug validation
  - Validates tenant membership via `current_principal()` (403 if not a member)
  - Looks up the store in the registry and sets `current_store` contextvar
  - Rewrites the path to `/api/*` or `/mcp/*` so mounted handlers see canonical routes
  - Rejects malformed slugs before DB roundtrips (404 immediately)
  - Passes through public prefixes (health, auth, admin, ui, static) unchanged

- **Store context management** (`stash_mcp/routing/context.py`): New module providing:
  - `set_current_store()` / `reset_current_store()` for contextvar lifecycle
  - `current_store()` to read the store (returns None if not set)
  - `require_store()` to read the store or raise RuntimeError (for tools/handlers that require it)

- **API handler updates** (`stash_mcp/api.py`):
  - Accept `USE_CURRENT_STORE` sentinel instead of a single `FileSystem`
  - Resolve filesystem at request time via `current_store()` when in auth mode
  - Add ETag support: `If-None-Match` (304), `If-Match` (412), strong ETags from git or content hash
  - Compute ETags from git blob SHA (git-tracked stores) or SHA-256 (filesystem stores)

- **MCP server updates** (`stash_mcp/mcp_server.py`):
  - Accept `USE_CURRENT_STORE` sentinel instead of a single `FileSystem`
  - Resolve filesystem and git backend at tool call time via `current_store()`
  - Skip static resource registration in auth mode (per-store registration owned by UI)
  - Register git tools unconditionally in auth mode (they raise if store has no git)

- **Main app initialization** (`stash_mcp/main.py`):
  - `_create_auth_enabled_app()` now builds a complete per-store routed app
  - Mounts MCP and REST handlers with `USE_CURRENT_STORE` sentinel
  - Wraps with `StoreResolverMiddleware` to handle tenant/store routing
  - Adds search endpoint shim that returns 503 (search disabled in v1 auth mode)

- **Filesystem and git backend enhancements**:
  - `FileSystem.content_hash()`: SHA-256 digest for non-git-tracked stores
  - `GitBackend.hash_object()`: Git blob SHA for ETag computation

- **Comprehensive test suite** (`tests/routing/`):
  - `test_store_resolver.py`: 410 lines covering path matching, ACL, contextvar isolation, concurrent request safety
  - `test_per_store_api.py`: 314 lines testing store isolation, ETag conditional requests
  - `test_per_store_mcp.py`: 225 lines testing MCP tool isolation and git/transaction tool behavior
  - `conftest.py`: Shared fixtures (in-memory DB, content directory, principal helpers)

## Notable Implementation Details

- **Slug validation**: Regex enforces lowercase alphanumeric + hyphens (no uppercase, underscores, or special chars) before any DB lookup
- **Contextvar safety**: Uses `Token.reset()` not `set(None)` to properly restore prior values in nested/concurrent contexts
- **ETag computation**: Strong ETags (quoted hex) from git blob SHA or file content hash; supports comma-separated lists and

https://claude.ai/code/session_017KqF3hJkSf5jTYxswAdLB7