### PR TITLE
Add admin HTTP API and CLI tooling for tenant/store management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 [project.scripts]
 stash-mcp = "stash_mcp.main:main"
 stash-mcp-stdio = "stash_mcp.server:run"
+stash-mcp-cli = "stash_mcp.cli:main"
 stash-mcp-migrate = "alembic.config:main"
 
 [project.optional-dependencies]
@@ -90,6 +91,9 @@ ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 "stash_mcp/ui.py" = ["E501"]
+# Problem Details classes use semantic names (Forbidden, ETagMismatch, …)
+# that intentionally don't end in "Error".
+"stash_mcp/errors.py" = ["N818"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/stash_mcp/admin/__init__.py
+++ b/stash_mcp/admin/__init__.py
@@ -1,0 +1,10 @@
+"""Admin HTTP surface — tenants, stores, users, memberships.
+
+All endpoints under :data:`router` require the in-flight principal to
+have ``admin`` role on the default tenant (see
+:func:`require_admin`). Errors render as RFC 7807 Problem Details.
+"""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/stash_mcp/admin/dependencies.py
+++ b/stash_mcp/admin/dependencies.py
@@ -1,0 +1,51 @@
+"""FastAPI dependency: ``require_admin``.
+
+In v1 admin is global — granted on the default tenant only — so the
+check is "principal has admin role on whatever tenant has slug
+``default``". Cross-tenant admins land in a follow-up spec.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
+
+from ..auth.context import current_principal
+from ..auth.principal import Principal
+from ..db.models import Tenant
+from ..db.session import get_session
+from ..errors import Forbidden, TenantNotFound, Unauthenticated
+
+_DEFAULT_TENANT_SLUG = "default"
+
+
+async def require_admin(
+    request: Request,  # noqa: ARG001 — kept for signature symmetry
+    session: AsyncSession = Depends(get_session),
+) -> Principal:
+    """Reject the request unless the caller is an admin on ``default``."""
+    principal = current_principal()
+    if principal is None:
+        raise Unauthenticated("admin endpoints require authentication")
+
+    tenant = (
+        await session.execute(
+            select(Tenant).where(Tenant.slug == _DEFAULT_TENANT_SLUG)
+        )
+    ).scalar_one_or_none()
+    if tenant is None:
+        # Without a default tenant we can't authorise anyone as admin —
+        # surface that as a 404 on the tenant so operators see the
+        # underlying cause rather than a misleading 403.
+        raise TenantNotFound(
+            f"default tenant ({_DEFAULT_TENANT_SLUG!r}) is missing"
+        )
+
+    if not principal.has_role_on(tenant.id, "admin"):
+        raise Forbidden("admin role required on the default tenant")
+    return principal
+
+
+__all__ = ["require_admin"]

--- a/stash_mcp/admin/routes.py
+++ b/stash_mcp/admin/routes.py
@@ -1,0 +1,634 @@
+"""``/admin/*`` HTTP handlers.
+
+All endpoints gated by :func:`require_admin`. Audit events for state-
+changing actions are written in the same DB transaction as the change so
+the audit log can't drift from the table state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth.principal import Principal
+from ..db.models import (
+    ApiToken,
+    AuditEvent,
+    Membership,
+    Store,
+    Tenant,
+    User,
+)
+from ..db.session import get_session
+from ..db.session import get_sessionmaker as get_session_factory
+from ..errors import (
+    ConfirmationRequired,
+    MembershipExists,
+    MembershipNotFound,
+    StoreAlreadyExists,
+    StoreNotFound,
+    TenantAlreadyExists,
+    TenantHasStores,
+    TenantNotFound,
+    UserNotFound,
+    ValidationError,
+)
+from ..stores.layout import store_root
+from ..stores.registry import (
+    StoreAlreadyProvisionedError,
+    get_store_registry,
+)
+from .dependencies import require_admin
+
+logger = logging.getLogger(__name__)
+
+
+# --- request/response models -----------------------------------------------
+
+
+class TenantCreate(BaseModel):
+    slug: str = Field(..., pattern=r"^[a-z0-9][a-z0-9-]{0,62}$")
+    display_name: str = Field(..., min_length=1, max_length=255)
+
+
+class TenantUpdate(BaseModel):
+    display_name: str = Field(..., min_length=1, max_length=255)
+
+
+class TenantInfo(BaseModel):
+    id: UUID
+    slug: str
+    display_name: str
+    created_at: datetime
+
+
+class StoreCreate(BaseModel):
+    slug: str = Field(..., pattern=r"^[a-z0-9][a-z0-9-]{0,62}$")
+    display_name: str = Field(..., min_length=1, max_length=255)
+    git_remote_url: str | None = Field(default=None)
+    git_branch: str = Field(default="main")
+
+
+class StoreInfo(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    slug: str
+    display_name: str
+    git_remote_url: str | None
+    git_branch: str
+    created_at: datetime
+
+
+class UserInfo(BaseModel):
+    id: UUID
+    oidc_sub: str
+    email: str
+    display_name: str
+    created_at: datetime
+    last_login_at: datetime | None
+
+
+class MembershipCreate(BaseModel):
+    user_id: UUID
+    tenant_id: UUID
+    role: str = Field(..., pattern=r"^(admin|member)$")
+
+
+class MembershipInfo(BaseModel):
+    id: UUID
+    user_id: UUID
+    tenant_id: UUID
+    role: str
+    source: str
+    created_at: datetime
+
+
+def _tenant_to_info(t: Tenant) -> TenantInfo:
+    return TenantInfo(
+        id=t.id,
+        slug=t.slug,
+        display_name=t.display_name,
+        created_at=t.created_at,
+    )
+
+
+def _store_to_info(s: Store) -> StoreInfo:
+    return StoreInfo(
+        id=s.id,
+        tenant_id=s.tenant_id,
+        slug=s.slug,
+        display_name=s.display_name,
+        git_remote_url=s.git_remote_url,
+        git_branch=s.git_branch,
+        created_at=s.created_at,
+    )
+
+
+def _user_to_info(u: User) -> UserInfo:
+    return UserInfo(
+        id=u.id,
+        oidc_sub=u.oidc_sub,
+        email=u.email,
+        display_name=u.display_name,
+        created_at=u.created_at,
+        last_login_at=u.last_login_at,
+    )
+
+
+def _membership_to_info(m: Membership) -> MembershipInfo:
+    return MembershipInfo(
+        id=m.id,
+        user_id=m.user_id,
+        tenant_id=m.tenant_id,
+        role=m.role,
+        source=m.source,
+        created_at=m.created_at,
+    )
+
+
+def _audit(
+    session: AsyncSession,
+    *,
+    actor: Principal,
+    action: str,
+    target_kind: str,
+    target_id: str,
+    tenant_id: UUID | None = None,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    session.add(
+        AuditEvent(
+            actor_user_id=actor.user_id,
+            actor_kind="user",
+            action=action,
+            target_kind=target_kind,
+            target_id=target_id,
+            tenant_id=tenant_id,
+            detail=json.dumps(detail) if detail else None,
+        )
+    )
+
+
+async def _get_tenant_or_404(
+    session: AsyncSession, tenant_id: UUID
+) -> Tenant:
+    tenant = await session.get(Tenant, tenant_id)
+    if tenant is None:
+        raise TenantNotFound(f"tenant {tenant_id} not found")
+    return tenant
+
+
+# --- router -----------------------------------------------------------------
+
+
+router = APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    dependencies=[Depends(require_admin)],
+)
+
+
+# Tenants -------------------------------------------------------------------
+
+
+@router.post("/tenants", response_model=TenantInfo, status_code=201)
+async def create_tenant(
+    body: TenantCreate,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> TenantInfo:
+    existing = (
+        await session.execute(select(Tenant).where(Tenant.slug == body.slug))
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise TenantAlreadyExists(f"tenant slug {body.slug!r} already in use")
+    tenant = Tenant(slug=body.slug, display_name=body.display_name)
+    session.add(tenant)
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise TenantAlreadyExists(
+            f"tenant slug {body.slug!r} already in use"
+        ) from exc
+    _audit(
+        session,
+        actor=actor,
+        action="tenant.created",
+        target_kind="tenant",
+        target_id=str(tenant.id),
+        tenant_id=tenant.id,
+        detail={"slug": tenant.slug, "display_name": tenant.display_name},
+    )
+    await session.commit()
+    await session.refresh(tenant)
+    return _tenant_to_info(tenant)
+
+
+@router.get("/tenants", response_model=list[TenantInfo])
+async def list_tenants(
+    session: AsyncSession = Depends(get_session),
+) -> list[TenantInfo]:
+    rows = (
+        (await session.execute(select(Tenant).order_by(Tenant.slug)))
+        .scalars()
+        .all()
+    )
+    return [_tenant_to_info(t) for t in rows]
+
+
+@router.get("/tenants/{tenant_id}", response_model=TenantInfo)
+async def get_tenant(
+    tenant_id: UUID,
+    session: AsyncSession = Depends(get_session),
+) -> TenantInfo:
+    return _tenant_to_info(await _get_tenant_or_404(session, tenant_id))
+
+
+@router.patch("/tenants/{tenant_id}", response_model=TenantInfo)
+async def update_tenant(
+    tenant_id: UUID,
+    body: TenantUpdate,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> TenantInfo:
+    tenant = await _get_tenant_or_404(session, tenant_id)
+    tenant.display_name = body.display_name
+    _audit(
+        session,
+        actor=actor,
+        action="tenant.renamed",
+        target_kind="tenant",
+        target_id=str(tenant.id),
+        tenant_id=tenant.id,
+        detail={"display_name": tenant.display_name},
+    )
+    await session.commit()
+    await session.refresh(tenant)
+    return _tenant_to_info(tenant)
+
+
+@router.delete("/tenants/{tenant_id}", status_code=204)
+async def delete_tenant(
+    tenant_id: UUID,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    tenant = await _get_tenant_or_404(session, tenant_id)
+    store_count = (
+        await session.execute(
+            select(func.count())
+            .select_from(Store)
+            .where(Store.tenant_id == tenant_id)
+        )
+    ).scalar_one()
+    if store_count:
+        raise TenantHasStores(
+            f"tenant {tenant.slug!r} owns {store_count} store(s); "
+            "delete the stores first"
+        )
+    _audit(
+        session,
+        actor=actor,
+        action="tenant.deleted",
+        target_kind="tenant",
+        target_id=str(tenant.id),
+        tenant_id=tenant.id,
+        detail={"slug": tenant.slug},
+    )
+    await session.delete(tenant)
+    await session.commit()
+
+
+# Stores --------------------------------------------------------------------
+
+
+@router.post(
+    "/tenants/{tenant_id}/stores",
+    response_model=StoreInfo,
+    status_code=201,
+)
+async def create_store(
+    tenant_id: UUID,
+    body: StoreCreate,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> StoreInfo:
+    tenant = await _get_tenant_or_404(session, tenant_id)
+    existing = (
+        await session.execute(
+            select(Store).where(
+                Store.tenant_id == tenant_id, Store.slug == body.slug
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise StoreAlreadyExists(
+            f"store {tenant.slug}/{body.slug} already exists"
+        )
+
+    store = Store(
+        tenant_id=tenant.id,
+        slug=body.slug,
+        display_name=body.display_name,
+        git_remote_url=body.git_remote_url,
+        git_branch=body.git_branch,
+    )
+    session.add(store)
+    _audit(
+        session,
+        actor=actor,
+        action="store.provisioned",
+        target_kind="store",
+        target_id=str(store.id),
+        tenant_id=tenant.id,
+        detail={
+            "tenant_slug": tenant.slug,
+            "slug": store.slug,
+            "git_remote_url": body.git_remote_url,
+            "git_branch": body.git_branch,
+        },
+    )
+    # Commit the row first so :meth:`StoreRegistry.provision` (which opens
+    # its own session to look the row up) can see it. If on-disk
+    # provisioning then fails we delete the row in a follow-up transaction
+    # rather than leaving it orphaned.
+    await session.commit()
+    await session.refresh(store)
+    store_id = store.id
+    tenant_slug = tenant.slug
+    store_slug = store.slug
+
+    registry = get_store_registry()
+    try:
+        await registry.provision(
+            tenant_id=tenant.id,
+            tenant_slug=tenant_slug,
+            store_slug=store_slug,
+            git_remote_url=body.git_remote_url,
+            git_branch=body.git_branch,
+        )
+    except StoreAlreadyProvisionedError as exc:
+        # The disk path already had content even though the DB had no row.
+        # Keep the row (admin can inspect it) but surface the conflict.
+        raise StoreAlreadyExists(
+            f"store {tenant_slug}/{store_slug} already provisioned on disk: {exc}"
+        ) from exc
+    except Exception:
+        # Provisioning failed: drop the just-created row so admin can
+        # retry without a duplicate-slug collision.
+        async with get_session_factory()() as cleanup:
+            row = await cleanup.get(Store, store_id)
+            if row is not None:
+                await cleanup.delete(row)
+                await cleanup.commit()
+        raise
+
+    return _store_to_info(store)
+
+
+@router.get(
+    "/tenants/{tenant_id}/stores", response_model=list[StoreInfo]
+)
+async def list_stores(
+    tenant_id: UUID,
+    session: AsyncSession = Depends(get_session),
+) -> list[StoreInfo]:
+    await _get_tenant_or_404(session, tenant_id)
+    rows = (
+        (
+            await session.execute(
+                select(Store)
+                .where(Store.tenant_id == tenant_id)
+                .order_by(Store.slug)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [_store_to_info(s) for s in rows]
+
+
+@router.delete(
+    "/tenants/{tenant_id}/stores/{slug}", status_code=204
+)
+async def delete_store(
+    tenant_id: UUID,
+    slug: str,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+    confirm: bool = Query(default=False),
+) -> None:
+    tenant = await _get_tenant_or_404(session, tenant_id)
+    if not confirm:
+        raise ConfirmationRequired(
+            "store deletion removes the on-disk repo recursively — "
+            "retry with ?confirm=true to proceed"
+        )
+    store = (
+        await session.execute(
+            select(Store).where(
+                Store.tenant_id == tenant_id, Store.slug == slug
+            )
+        )
+    ).scalar_one_or_none()
+    if store is None:
+        raise StoreNotFound(f"store {tenant.slug}/{slug} not found")
+
+    registry = get_store_registry()
+    registry.invalidate(tenant.slug, store.slug)
+
+    on_disk = store_root(str(tenant.id), store.slug)
+    if on_disk.exists():
+        try:
+            shutil.rmtree(on_disk)
+        except OSError as exc:
+            logger.error("Failed to remove on-disk store %s: %s", on_disk, exc)
+            raise
+
+    _audit(
+        session,
+        actor=actor,
+        action="store.deleted",
+        target_kind="store",
+        target_id=str(store.id),
+        tenant_id=tenant.id,
+        detail={"tenant_slug": tenant.slug, "slug": store.slug},
+    )
+    await session.delete(store)
+    await session.commit()
+
+
+# Users ---------------------------------------------------------------------
+
+
+@router.get("/users", response_model=list[UserInfo])
+async def list_users(
+    session: AsyncSession = Depends(get_session),
+) -> list[UserInfo]:
+    rows = (
+        (await session.execute(select(User).order_by(User.email)))
+        .scalars()
+        .all()
+    )
+    return [_user_to_info(u) for u in rows]
+
+
+@router.get("/users/{user_id}", response_model=UserInfo)
+async def get_user(
+    user_id: UUID,
+    session: AsyncSession = Depends(get_session),
+) -> UserInfo:
+    user = await session.get(User, user_id)
+    if user is None:
+        raise UserNotFound(f"user {user_id} not found")
+    return _user_to_info(user)
+
+
+@router.delete("/users/{user_id}", status_code=204)
+async def delete_user(
+    user_id: UUID,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    user = await session.get(User, user_id)
+    if user is None:
+        raise UserNotFound(f"user {user_id} not found")
+
+    # Memberships cascade via FK; API tokens cascade too, but the spec
+    # asks us to also write a revocation timestamp on still-live tokens
+    # so any audit row tracing this user's tokens reads sanely.
+    now = datetime.now(UTC)
+    live_tokens = (
+        (
+            await session.execute(
+                select(ApiToken).where(
+                    ApiToken.user_id == user.id,
+                    ApiToken.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for t in live_tokens:
+        t.revoked_at = now
+
+    _audit(
+        session,
+        actor=actor,
+        action="user.deleted",
+        target_kind="user",
+        target_id=str(user.id),
+        detail={"email": user.email, "oidc_sub": user.oidc_sub},
+    )
+    await session.delete(user)
+    await session.commit()
+
+
+# Memberships ---------------------------------------------------------------
+
+
+@router.post(
+    "/memberships", response_model=MembershipInfo, status_code=201
+)
+async def grant_membership(
+    body: MembershipCreate,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> MembershipInfo:
+    user = await session.get(User, body.user_id)
+    if user is None:
+        raise UserNotFound(f"user {body.user_id} not found")
+    tenant = await session.get(Tenant, body.tenant_id)
+    if tenant is None:
+        raise TenantNotFound(f"tenant {body.tenant_id} not found")
+
+    existing = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == body.user_id,
+                Membership.tenant_id == body.tenant_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise MembershipExists(
+            f"user {user.email} already has a membership on tenant {tenant.slug!r} "
+            f"(source={existing.source!r}, role={existing.role!r})"
+        )
+
+    membership = Membership(
+        user_id=body.user_id,
+        tenant_id=body.tenant_id,
+        role=body.role,
+        source="manual",
+    )
+    session.add(membership)
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise ValidationError(f"failed to grant membership: {exc}") from exc
+
+    _audit(
+        session,
+        actor=actor,
+        action="membership.granted",
+        target_kind="membership",
+        target_id=str(membership.id),
+        tenant_id=tenant.id,
+        detail={
+            "user_id": str(user.id),
+            "user_email": user.email,
+            "role": body.role,
+            "source": "manual",
+        },
+    )
+    await session.commit()
+    await session.refresh(membership)
+    return _membership_to_info(membership)
+
+
+@router.delete("/memberships/{membership_id}", status_code=204)
+async def revoke_membership(
+    membership_id: UUID,
+    actor: Principal = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    membership = await session.get(Membership, membership_id)
+    if membership is None:
+        raise MembershipNotFound(f"membership {membership_id} not found")
+    if membership.source != "manual":
+        raise ValidationError(
+            "only source='manual' memberships can be revoked via this endpoint"
+        )
+
+    _audit(
+        session,
+        actor=actor,
+        action="membership.revoked",
+        target_kind="membership",
+        target_id=str(membership.id),
+        tenant_id=membership.tenant_id,
+        detail={
+            "user_id": str(membership.user_id),
+            "role": membership.role,
+            "source": membership.source,
+        },
+    )
+    await session.delete(membership)
+    await session.commit()
+
+
+__all__ = ["router"]

--- a/stash_mcp/auth/oidc_provider.py
+++ b/stash_mcp/auth/oidc_provider.py
@@ -19,21 +19,19 @@ import logging
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import Any
 
 import httpx
 from authlib.jose import JsonWebKey, JsonWebToken
 from authlib.jose.errors import JoseError
-from sqlalchemy import select
 from starlette.requests import Request
 
 from ..config import Config
-from ..db.models import AuditEvent, Membership, Tenant, User
 from ..db.session import get_sessionmaker
 from .principal import Principal, Role
 from .provider import AuthError, AuthProvider
 from .tokens import looks_like_stash_token
+from .users import upsert_user_and_memberships
 
 logger = logging.getLogger(__name__)
 
@@ -237,52 +235,13 @@ class OIDCAuthProvider(AuthProvider):
     # --- Principal materialisation -----------------------------------------
 
     async def _materialize_principal(self, claims: dict) -> Principal:
-        sub = claims["sub"]
-        email = _first_str(claims, ["email"]) or ""
-        display_name = (
-            _first_str(claims, ["name", "preferred_username", "email"]) or sub
-        )
-
-        groups_raw = claims.get(Config.OIDC_GROUPS_CLAIM, [])
-        if not isinstance(groups_raw, list):
-            groups_raw = []
-        groups: set[str] = {g for g in groups_raw if isinstance(g, str)}
-
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
-            # Upsert user.
-            user = (
-                await session.execute(select(User).where(User.oidc_sub == sub))
-            ).scalar_one_or_none()
-            now = datetime.now(UTC)
-            if user is None:
-                user = User(
-                    oidc_sub=sub,
-                    email=email,
-                    display_name=display_name,
-                    last_login_at=now,
-                )
-                session.add(user)
-                await session.flush()
-            else:
-                # Keep profile fields fresh.
-                if email and user.email != email:
-                    user.email = email
-                if display_name and user.display_name != display_name:
-                    user.display_name = display_name
-                user.last_login_at = now
-
-            # Group → admin membership sync. Manual wins (see README).
-            await self._sync_admin_membership(session, user, groups)
-
-            # Load memberships freshly for the Principal.
-            await session.refresh(user, attribute_names=["memberships"])
+            user = await upsert_user_and_memberships(session, claims)
             tenant_roles: dict = {
                 m.tenant_id: _coerce_role(m.role) for m in user.memberships
             }
-
             await session.commit()
-
             principal = Principal(
                 user_id=user.id,
                 oidc_sub=user.oidc_sub,
@@ -293,134 +252,6 @@ class OIDCAuthProvider(AuthProvider):
                 claims=dict(claims),
             )
         return principal
-
-    async def _sync_admin_membership(
-        self, session, user: User, groups: set[str]
-    ) -> None:
-        """Maintain a group-derived admin membership on the default tenant.
-
-        Rules (locked in README.md):
-
-        - For tenants the user has a ``source='manual'`` row on: skip entirely.
-        - Otherwise, if ``OIDC_ADMIN_GROUP`` ∈ groups → upsert
-          ``source='oidc_group', role='admin'`` on the default tenant.
-        - For any existing ``source='oidc_group'`` row whose group no longer
-          applies, delete it.
-        - Audit every change via ``audit_events``.
-        """
-        admin_group = Config.OIDC_ADMIN_GROUP
-        if not admin_group:
-            return  # no admin sync configured
-
-        # Existing memberships, keyed by tenant_id.
-        existing = (
-            await session.execute(
-                select(Membership).where(Membership.user_id == user.id)
-            )
-        ).scalars().all()
-        by_tenant: dict[Any, Membership] = {m.tenant_id: m for m in existing}
-
-        default_tenant = await self._ensure_default_tenant(session)
-
-        # Manual on the default tenant? Manual wins — skip this tenant
-        # entirely, and don't create a parallel oidc_group row.
-        existing_on_default = by_tenant.get(default_tenant.id)
-        manual_on_default = (
-            existing_on_default is not None
-            and existing_on_default.source == "manual"
-        )
-
-        admin_wanted = admin_group in groups
-        if admin_wanted and not manual_on_default:
-            if existing_on_default is None:
-                session.add(
-                    Membership(
-                        user_id=user.id,
-                        tenant_id=default_tenant.id,
-                        role="admin",
-                        source="oidc_group",
-                    )
-                )
-                _audit(
-                    session,
-                    user,
-                    default_tenant.id,
-                    old_role=None,
-                    new_role="admin",
-                )
-            else:
-                # Pre-existing oidc_group row. Update role if drifted.
-                if existing_on_default.role != "admin":
-                    _audit(
-                        session,
-                        user,
-                        default_tenant.id,
-                        old_role=existing_on_default.role,
-                        new_role="admin",
-                    )
-                    existing_on_default.role = "admin"
-                # No-op if already admin.
-
-        # Remove stale oidc_group rows. Only the default tenant is in scope
-        # in v1, so any oidc_group row that ISN'T on default — or that is on
-        # default but the user is no longer in the admin group — gets pruned.
-        for tenant_id, m in by_tenant.items():
-            if m.source != "oidc_group":
-                continue
-            if tenant_id == default_tenant.id and admin_wanted and not manual_on_default:
-                continue  # we just kept/created this one
-            _audit(
-                session,
-                user,
-                tenant_id,
-                old_role=m.role,
-                new_role=None,
-            )
-            await session.delete(m)
-
-    async def _ensure_default_tenant(self, session) -> Tenant:
-        tenant = (
-            await session.execute(
-                select(Tenant).where(Tenant.slug == _DEFAULT_TENANT_SLUG)
-            )
-        ).scalar_one_or_none()
-        if tenant is None:
-            tenant = Tenant(
-                slug=_DEFAULT_TENANT_SLUG,
-                display_name=_DEFAULT_TENANT_DISPLAY_NAME,
-            )
-            session.add(tenant)
-            await session.flush()
-        return tenant
-
-
-def _audit(
-    session,
-    user: User,
-    tenant_id: Any,
-    *,
-    old_role: str | None,
-    new_role: str | None,
-) -> None:
-    session.add(
-        AuditEvent(
-            actor_user_id=user.id,
-            actor_kind="system",
-            action="membership.synced",
-            target_kind="membership",
-            target_id=str(user.id),
-            tenant_id=tenant_id,
-            detail=json.dumps({"old_role": old_role, "new_role": new_role}),
-        )
-    )
-
-
-def _first_str(d: dict, keys: list[str]) -> str | None:
-    for k in keys:
-        v = d.get(k)
-        if isinstance(v, str) and v:
-            return v
-    return None
 
 
 def _b64url_decode(value: str) -> bytes:

--- a/stash_mcp/auth/routes.py
+++ b/stash_mcp/auth/routes.py
@@ -1,0 +1,335 @@
+"""``/auth/*`` routes — OIDC login, callback, logout, and API-token CRUD.
+
+``/auth/login`` and ``/auth/callback`` implement the OIDC authorisation
+code flow via :mod:`authlib`. On a successful callback we materialise the
+DB user via :func:`upsert_user_and_memberships`, sign a Stash session
+cookie, and 302 to the originating ``next`` URL.
+
+``/auth/tokens`` lets a cookie-authenticated user mint and revoke their
+own Stash API tokens. Bearer-JWT and api-token callers are explicitly
+denied — the discrimination is the whole point of the three-valued
+``auth_method`` enum on :class:`Principal`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from authlib.integrations.starlette_client import OAuth
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+
+from ..config import Config
+from ..db.models import ApiToken, AuditEvent
+from ..db.session import get_session
+from ..errors import (
+    Forbidden,
+    TokenNotFound,
+    Unauthenticated,
+    ValidationError,
+)
+from .context import current_principal
+from .principal import Principal
+from .sessions import issue_session
+from .tokens import generate_token, hash_with_active_key
+from .users import upsert_user_and_memberships
+
+logger = logging.getLogger(__name__)
+
+# authlib OAuth instance. Lazily configured the first time we need it so
+# importing this module is safe under ``AUTH_ENABLED=False``.
+_oauth: OAuth | None = None
+
+
+def _is_local_dev() -> bool:
+    """Heuristic for whether we should drop the ``Secure`` cookie flag."""
+    host = (Config.HOST or "").strip()
+    return host in ("127.0.0.1", "localhost", "0.0.0.0") or os.getenv(
+        "STASH_INSECURE_COOKIES"
+    ) == "true"
+
+
+def get_oauth() -> OAuth:
+    """Return the process-wide :class:`OAuth` instance, registering on first use."""
+    global _oauth
+    if _oauth is None:
+        oauth = OAuth()
+        oauth.register(
+            name="idp",
+            server_metadata_url=Config.OIDC_DISCOVERY_URL,
+            client_id=Config.OIDC_CLIENT_ID,
+            client_secret=Config.OIDC_CLIENT_SECRET,
+            client_kwargs={"scope": Config.OIDC_SCOPES},
+        )
+        _oauth = oauth
+    return _oauth
+
+
+def reset_oauth_for_tests() -> None:
+    """Drop the cached OAuth registration. Test-only."""
+    global _oauth
+    _oauth = None
+
+
+# --- request/response models -------------------------------------------------
+
+
+class TokenCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    scopes: list[str] = Field(default_factory=lambda: ["read", "write"])
+    expires_in_days: int | None = Field(default=90, ge=1, le=3650)
+
+
+class TokenIssued(BaseModel):
+    id: UUID
+    name: str
+    scopes: list[str]
+    token: str  # plaintext — returned ONCE
+    created_at: datetime
+    expires_at: datetime | None
+
+
+class TokenInfo(BaseModel):
+    id: UUID
+    name: str
+    scopes: list[str]
+    created_at: datetime
+    last_used_at: datetime | None
+    expires_at: datetime | None
+    revoked_at: datetime | None
+
+
+def _parse_scopes(raw: str) -> list[str]:
+    return [s for s in raw.split(",") if s]
+
+
+def _serialize_token(row: ApiToken) -> TokenInfo:
+    return TokenInfo(
+        id=row.id,
+        name=row.name,
+        scopes=_parse_scopes(row.scopes),
+        created_at=row.created_at,
+        last_used_at=row.last_used_at,
+        expires_at=row.expires_at,
+        revoked_at=row.revoked_at,
+    )
+
+
+# --- session dependency -----------------------------------------------------
+
+
+def require_session() -> Principal:
+    """FastAPI dependency: principal must be cookie-authenticated.
+
+    Bearer-JWT (``oidc``) and api-token callers get 403 — only browser
+    sessions are allowed to mint or revoke API tokens.
+    """
+    principal = current_principal()
+    if principal is None:
+        raise Unauthenticated("login required to manage API tokens")
+    if principal.auth_method != "session":
+        raise Forbidden(
+            "API token management requires a browser session cookie"
+        )
+    return principal
+
+
+# --- router -----------------------------------------------------------------
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.get("/login")
+async def login(request: Request, next: str = "/ui") -> Any:
+    """Kick off the OIDC authorization-code flow.
+
+    Stores the ``next`` path in the Starlette session (signed cookie owned
+    by ``SessionMiddleware``) so the callback can land the browser where
+    it asked to go.
+    """
+    redirect_uri = str(request.url_for("oidc_callback"))
+    request.session["next"] = next
+    return await get_oauth().idp.authorize_redirect(request, redirect_uri)
+
+
+@router.get("/callback", name="oidc_callback")
+async def callback(
+    request: Request, session: AsyncSession = Depends(get_session)
+) -> RedirectResponse:
+    """Complete the OIDC dance and issue the Stash session cookie."""
+    token = await get_oauth().idp.authorize_access_token(request)
+    claims = token.get("userinfo") or {}
+    if not claims:
+        # authlib usually parses the id_token for us; fall back to the
+        # raw id_token claims when the IdP omits userinfo.
+        claims = token.get("id_token_claims", {}) or {}
+    if "sub" not in claims:
+        raise ValidationError("OIDC callback returned no usable claims")
+
+    user = await upsert_user_and_memberships(session, claims)
+    await session.commit()
+
+    cookie_value = issue_session(user_id=str(user.id), oidc_sub=user.oidc_sub)
+    next_path = request.session.pop("next", "/ui")
+    if not isinstance(next_path, str) or not next_path.startswith("/"):
+        next_path = "/ui"
+
+    resp = RedirectResponse(url=next_path, status_code=302)
+    resp.set_cookie(
+        Config.SESSION_COOKIE_NAME,
+        cookie_value,
+        max_age=Config.SESSION_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=not _is_local_dev(),
+        samesite="lax",
+        path="/",
+    )
+    return resp
+
+
+@router.post("/logout")
+async def logout(request: Request) -> RedirectResponse:
+    """Clear the Stash session cookie. Does not call IdP RP-logout."""
+    next_path = request.query_params.get("next", "/ui")
+    if not next_path.startswith("/"):
+        next_path = "/ui"
+    resp = RedirectResponse(url=next_path, status_code=302)
+    resp.delete_cookie(Config.SESSION_COOKIE_NAME, path="/")
+    request.session.pop("next", None)
+    return resp
+
+
+# Allow GET as a convenience for the UI's "Sign out" link.
+@router.get("/logout")
+async def logout_get(request: Request) -> RedirectResponse:
+    return await logout(request)
+
+
+@router.get("/tokens", response_model=list[TokenInfo])
+async def list_tokens(
+    principal: Principal = Depends(require_session),
+    session: AsyncSession = Depends(get_session),
+    include_revoked: bool = Query(default=False),
+) -> list[TokenInfo]:
+    stmt = select(ApiToken).where(ApiToken.user_id == principal.user_id)
+    if not include_revoked:
+        stmt = stmt.where(ApiToken.revoked_at.is_(None))
+    rows = (await session.execute(stmt.order_by(ApiToken.created_at.desc()))).scalars().all()
+    return [_serialize_token(r) for r in rows]
+
+
+@router.post("/tokens", response_model=TokenIssued, status_code=201)
+async def create_token(
+    body: TokenCreate,
+    principal: Principal = Depends(require_session),
+    session: AsyncSession = Depends(get_session),
+) -> TokenIssued:
+    valid_scopes = {"read", "write", "admin"}
+    if not body.scopes:
+        raise ValidationError("scopes must not be empty")
+    bad = [s for s in body.scopes if s not in valid_scopes]
+    if bad:
+        raise ValidationError(
+            f"unknown scopes: {bad}; valid scopes are {sorted(valid_scopes)}"
+        )
+
+    keys = Config.AUTH_TOKEN_HMAC_KEYS
+    plaintext = generate_token()
+    token_hash, key_version = hash_with_active_key(plaintext, keys=keys)
+
+    expires_at = None
+    if body.expires_in_days is not None:
+        expires_at = datetime.now(UTC) + timedelta(days=body.expires_in_days)
+
+    row = ApiToken(
+        user_id=principal.user_id,
+        token_hash=token_hash,
+        key_version=key_version,
+        name=body.name,
+        scopes=",".join(sorted(set(body.scopes))),
+        expires_at=expires_at,
+    )
+    session.add(row)
+    await session.flush()
+
+    session.add(
+        AuditEvent(
+            actor_user_id=principal.user_id,
+            actor_kind="user",
+            action="token.issued",
+            target_kind="token",
+            target_id=str(row.id),
+            detail=json.dumps(
+                {
+                    "name": row.name,
+                    "scopes": _parse_scopes(row.scopes),
+                    "expires_at": row.expires_at.isoformat()
+                    if row.expires_at
+                    else None,
+                }
+            ),
+        )
+    )
+    await session.commit()
+    await session.refresh(row)
+
+    return TokenIssued(
+        id=row.id,
+        name=row.name,
+        scopes=_parse_scopes(row.scopes),
+        token=plaintext,
+        created_at=row.created_at,
+        expires_at=row.expires_at,
+    )
+
+
+@router.delete("/tokens/{token_id}", status_code=204)
+async def revoke_token(
+    token_id: UUID,
+    principal: Principal = Depends(require_session),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    row = (
+        await session.execute(
+            select(ApiToken).where(
+                ApiToken.id == token_id,
+                ApiToken.user_id == principal.user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise TokenNotFound()
+    if row.revoked_at is None:
+        row.revoked_at = datetime.now(UTC)
+        session.add(
+            AuditEvent(
+                actor_user_id=principal.user_id,
+                actor_kind="user",
+                action="token.revoked",
+                target_kind="token",
+                target_id=str(row.id),
+                detail=json.dumps({"name": row.name}),
+            )
+        )
+    await session.commit()
+
+
+__all__ = [
+    "router",
+    "require_session",
+    "get_oauth",
+    "reset_oauth_for_tests",
+    "TokenCreate",
+    "TokenIssued",
+    "TokenInfo",
+]

--- a/stash_mcp/auth/users.py
+++ b/stash_mcp/auth/users.py
@@ -1,0 +1,201 @@
+"""Shared helper for upserting users + memberships from OIDC claims.
+
+Both the bearer-JWT path (``OIDCAuthProvider._materialize_principal``) and
+the cookie-issuance path (``/auth/callback`` in :mod:`stash_mcp.auth.routes`)
+need to materialise a DB user from an OIDC claim set and refresh group-
+derived memberships with the "manual wins" precedence locked in the auth
+README.
+
+The bearer path historically inlined this; spec 05 factors it out so the
+callback can produce the same user_id+memberships state without
+duplicating the upsert logic.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import Config
+from ..db.models import AuditEvent, Membership, Tenant, User
+
+_DEFAULT_TENANT_SLUG = "default"
+_DEFAULT_TENANT_DISPLAY_NAME = "Default tenant"
+
+
+def _first_str(d: dict, keys: list[str]) -> str | None:
+    for k in keys:
+        v = d.get(k)
+        if isinstance(v, str) and v:
+            return v
+    return None
+
+
+async def ensure_default_tenant(session: AsyncSession) -> Tenant:
+    """Return the default tenant row, creating it if missing."""
+    tenant = (
+        await session.execute(
+            select(Tenant).where(Tenant.slug == _DEFAULT_TENANT_SLUG)
+        )
+    ).scalar_one_or_none()
+    if tenant is None:
+        tenant = Tenant(
+            slug=_DEFAULT_TENANT_SLUG,
+            display_name=_DEFAULT_TENANT_DISPLAY_NAME,
+        )
+        session.add(tenant)
+        await session.flush()
+    return tenant
+
+
+def _audit_membership_change(
+    session: AsyncSession,
+    user: User,
+    tenant_id: UUID,
+    *,
+    old_role: str | None,
+    new_role: str | None,
+) -> None:
+    session.add(
+        AuditEvent(
+            actor_user_id=user.id,
+            actor_kind="system",
+            action="membership.synced",
+            target_kind="membership",
+            target_id=str(user.id),
+            tenant_id=tenant_id,
+            detail=json.dumps({"old_role": old_role, "new_role": new_role}),
+        )
+    )
+
+
+async def _sync_admin_membership(
+    session: AsyncSession, user: User, groups: set[str]
+) -> None:
+    """Maintain a group-derived admin membership on the default tenant.
+
+    Mirrors :meth:`OIDCAuthProvider._sync_admin_membership` exactly — see
+    its docstring for the rules. Kept here so the callback route shares
+    the same code path.
+    """
+    admin_group = Config.OIDC_ADMIN_GROUP
+    if not admin_group:
+        return
+
+    existing = (
+        (
+            await session.execute(
+                select(Membership).where(Membership.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_tenant: dict[Any, Membership] = {m.tenant_id: m for m in existing}
+
+    default_tenant = await ensure_default_tenant(session)
+    existing_on_default = by_tenant.get(default_tenant.id)
+    manual_on_default = (
+        existing_on_default is not None
+        and existing_on_default.source == "manual"
+    )
+
+    admin_wanted = admin_group in groups
+    if admin_wanted and not manual_on_default:
+        if existing_on_default is None:
+            session.add(
+                Membership(
+                    user_id=user.id,
+                    tenant_id=default_tenant.id,
+                    role="admin",
+                    source="oidc_group",
+                )
+            )
+            _audit_membership_change(
+                session, user, default_tenant.id, old_role=None, new_role="admin"
+            )
+        else:
+            if existing_on_default.role != "admin":
+                _audit_membership_change(
+                    session,
+                    user,
+                    default_tenant.id,
+                    old_role=existing_on_default.role,
+                    new_role="admin",
+                )
+                existing_on_default.role = "admin"
+
+    for tenant_id, m in by_tenant.items():
+        if m.source != "oidc_group":
+            continue
+        if (
+            tenant_id == default_tenant.id
+            and admin_wanted
+            and not manual_on_default
+        ):
+            continue
+        _audit_membership_change(
+            session, user, tenant_id, old_role=m.role, new_role=None
+        )
+        await session.delete(m)
+
+
+async def upsert_user_and_memberships(
+    session: AsyncSession, claims: dict
+) -> User:
+    """Upsert the ``users`` row and refresh group-derived memberships.
+
+    Commits are the caller's responsibility — both callers
+    (:class:`OIDCAuthProvider` and the ``/auth/callback`` handler) want to
+    commit alongside other state (e.g. a session-cookie issuance audit
+    event).
+    """
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise ValueError("OIDC claims missing 'sub'")
+    email = _first_str(claims, ["email"]) or ""
+    display_name = (
+        _first_str(claims, ["name", "preferred_username", "email"]) or sub
+    )
+
+    groups_raw = claims.get(Config.OIDC_GROUPS_CLAIM, [])
+    if not isinstance(groups_raw, list):
+        groups_raw = []
+    groups: set[str] = {g for g in groups_raw if isinstance(g, str)}
+
+    user = (
+        await session.execute(select(User).where(User.oidc_sub == sub))
+    ).scalar_one_or_none()
+    now = datetime.now(UTC)
+    if user is None:
+        user = User(
+            oidc_sub=sub,
+            email=email,
+            display_name=display_name,
+            last_login_at=now,
+        )
+        session.add(user)
+        await session.flush()
+    else:
+        if email and user.email != email:
+            user.email = email
+        if display_name and user.display_name != display_name:
+            user.display_name = display_name
+        user.last_login_at = now
+
+    await _sync_admin_membership(session, user, groups)
+
+    # Refresh so callers see the up-to-date memberships collection.
+    await session.refresh(user, attribute_names=["memberships"])
+    return user
+
+
+__all__ = [
+    "ensure_default_tenant",
+    "upsert_user_and_memberships",
+]

--- a/stash_mcp/cli/__init__.py
+++ b/stash_mcp/cli/__init__.py
@@ -1,0 +1,17 @@
+"""``stash-mcp-cli`` — admin tooling for tenant/store provisioning.
+
+Intentionally narrow: this is for the "the IdP is broken and I need to
+fix something" path, plus tenant/store provisioning automation. It is
+*not* an alternative way to mint API tokens — those only come from
+``/auth/tokens`` after an OIDC login.
+"""
+
+def main(argv: list[str] | None = None) -> int:
+    """Lazy wrapper so ``python -m stash_mcp.cli`` doesn't double-import
+    ``__main__`` when the entry-point script also imports the package."""
+    from .__main__ import main as _main
+
+    return _main(argv)
+
+
+__all__ = ["main"]

--- a/stash_mcp/cli/__main__.py
+++ b/stash_mcp/cli/__main__.py
@@ -1,0 +1,109 @@
+"""Entry point for ``python -m stash_mcp.cli`` / ``stash-mcp-cli``.
+
+Argparse layout:
+
+    stash-mcp-cli [--database-url URL] <noun> <verb> [args...]
+
+Reading ``STASH_DATABASE_URL`` from env is the default; the
+``--database-url`` flag overrides it. All commands run synchronously
+against the configured DB — they are admin tooling, not part of the
+request path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from ..config import Config
+from .commands import run_command
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stash-mcp-cli",
+        description="Admin tooling for Stash-MCP tenant/store provisioning.",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help=(
+            "SQLAlchemy async URL. Defaults to $STASH_DATABASE_URL "
+            "(or Config.DATABASE_URL when set in env)."
+        ),
+    )
+    sub = parser.add_subparsers(dest="noun", required=True)
+
+    # tenant
+    tenant = sub.add_parser("tenant", help="manage tenants").add_subparsers(
+        dest="verb", required=True
+    )
+    t_create = tenant.add_parser("create", help="create a tenant")
+    t_create.add_argument("--slug", required=True)
+    t_create.add_argument("--name", required=True, help="display name")
+    tenant.add_parser("list", help="list tenants")
+
+    # store
+    store = sub.add_parser("store", help="manage stores").add_subparsers(
+        dest="verb", required=True
+    )
+    s_create = store.add_parser("create", help="create a store")
+    s_create.add_argument("--tenant", required=True, help="tenant slug")
+    s_create.add_argument("--slug", required=True)
+    s_create.add_argument("--display-name", default=None)
+    s_create.add_argument(
+        "--remote",
+        default=None,
+        help="optional git remote URL to clone for initial content",
+    )
+    s_create.add_argument("--branch", default="main")
+    s_list = store.add_parser("list", help="list stores for a tenant")
+    s_list.add_argument("--tenant", required=True)
+
+    # user
+    user = sub.add_parser("user", help="inspect users").add_subparsers(
+        dest="verb", required=True
+    )
+    user.add_parser("list", help="list users")
+
+    # membership
+    mem = sub.add_parser(
+        "membership", help="manage manual tenant memberships"
+    ).add_subparsers(dest="verb", required=True)
+    m_grant = mem.add_parser("grant", help="grant a manual membership")
+    m_grant.add_argument("--user-email", required=True)
+    m_grant.add_argument("--tenant", required=True, help="tenant slug")
+    m_grant.add_argument(
+        "--role", required=True, choices=("admin", "member")
+    )
+    m_revoke = mem.add_parser("revoke", help="revoke a manual membership")
+    m_revoke.add_argument("membership_id")
+
+    return parser
+
+
+def _resolve_database_url(arg: str | None) -> str:
+    if arg:
+        return arg
+    return Config.DATABASE_URL
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+
+    url = _resolve_database_url(ns.database_url)
+    engine = create_async_engine(url, future=True)
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        return run_command((ns.noun, ns.verb), ns, sm)
+    finally:
+        # ``engine.dispose()`` is async; we're in a sync main, so just let
+        # the connection pool drop on exit. CLI commands are one-shot.
+        pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stash_mcp/cli/commands.py
+++ b/stash_mcp/cli/commands.py
@@ -1,0 +1,253 @@
+"""Implementation of the ``stash-mcp-cli`` subcommands.
+
+Each ``cmd_*`` function takes the parsed ``argparse.Namespace`` and the
+:class:`async_sessionmaker` to use. Output is plain text on stdout so the
+commands compose with shell pipelines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.orm import selectinload
+
+from ..db.models import Membership, Store, Tenant, User
+from ..stores.layout import store_root
+from ..stores.registry import (
+    StoreAlreadyProvisionedError,
+    get_store_registry,
+)
+
+
+class CliError(RuntimeError):
+    """Raised on user-visible CLI failures. The main wrapper prints the
+    message and exits non-zero."""
+
+
+async def cmd_tenant_create(ns: Any, sm: async_sessionmaker) -> str:
+    async with sm() as session:
+        existing = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == ns.slug)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise CliError(f"tenant {ns.slug!r} already exists")
+        tenant = Tenant(slug=ns.slug, display_name=ns.name)
+        session.add(tenant)
+        await session.commit()
+        await session.refresh(tenant)
+    return f"created tenant {tenant.slug} ({tenant.id})"
+
+
+async def cmd_tenant_list(_ns: Any, sm: async_sessionmaker) -> str:
+    async with sm() as session:
+        rows = (
+            (await session.execute(select(Tenant).order_by(Tenant.slug)))
+            .scalars()
+            .all()
+        )
+    if not rows:
+        return "(no tenants)"
+    lines = [f"{t.slug:30} {t.id} {t.display_name}" for t in rows]
+    return "\n".join(lines)
+
+
+async def cmd_store_create(ns: Any, sm: async_sessionmaker) -> str:
+    async with sm() as session:
+        tenant = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == ns.tenant)
+            )
+        ).scalar_one_or_none()
+        if tenant is None:
+            raise CliError(f"tenant {ns.tenant!r} not found")
+        existing = (
+            await session.execute(
+                select(Store).where(
+                    Store.tenant_id == tenant.id, Store.slug == ns.slug
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise CliError(
+                f"store {tenant.slug}/{ns.slug} already exists"
+            )
+        store = Store(
+            tenant_id=tenant.id,
+            slug=ns.slug,
+            display_name=ns.display_name or ns.slug.title(),
+            git_remote_url=ns.remote,
+            git_branch=ns.branch,
+        )
+        session.add(store)
+        await session.flush()
+        tenant_id = tenant.id
+        tenant_slug = tenant.slug
+        store_id = store.id
+        store_slug = store.slug
+        await session.commit()
+
+    registry = get_store_registry()
+    try:
+        await registry.provision(
+            tenant_id=tenant_id,
+            tenant_slug=tenant_slug,
+            store_slug=store_slug,
+            git_remote_url=ns.remote,
+            git_branch=ns.branch,
+        )
+    except StoreAlreadyProvisionedError as exc:
+        raise CliError(
+            f"store row created but on-disk repo at "
+            f"{store_root(str(tenant_id), store_slug)} already exists: {exc}"
+        ) from exc
+    return (
+        f"created store {tenant_slug}/{store_slug} ({store_id}) at "
+        f"{store_root(str(tenant_id), store_slug)}"
+    )
+
+
+async def cmd_store_list(ns: Any, sm: async_sessionmaker) -> str:
+    async with sm() as session:
+        tenant = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == ns.tenant)
+            )
+        ).scalar_one_or_none()
+        if tenant is None:
+            raise CliError(f"tenant {ns.tenant!r} not found")
+        rows = (
+            (
+                await session.execute(
+                    select(Store)
+                    .where(Store.tenant_id == tenant.id)
+                    .order_by(Store.slug)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    if not rows:
+        return "(no stores)"
+    lines = [
+        f"{s.slug:30} {s.id} branch={s.git_branch} remote={s.git_remote_url or '-'}"
+        for s in rows
+    ]
+    return "\n".join(lines)
+
+
+async def cmd_user_list(_ns: Any, sm: async_sessionmaker) -> str:
+    async with sm() as session:
+        rows = (
+            (await session.execute(select(User).order_by(User.email)))
+            .scalars()
+            .all()
+        )
+    if not rows:
+        return "(no users)"
+    lines = [
+        f"{u.email:40} {u.id} sub={u.oidc_sub} name={u.display_name!r}"
+        for u in rows
+    ]
+    return "\n".join(lines)
+
+
+async def cmd_membership_grant(ns: Any, sm: async_sessionmaker) -> str:
+    async with sm() as session:
+        user = (
+            await session.execute(
+                select(User)
+                .options(selectinload(User.memberships))
+                .where(User.email == ns.user_email)
+            )
+        ).scalar_one_or_none()
+        if user is None:
+            raise CliError(f"user {ns.user_email!r} not found")
+        tenant = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == ns.tenant)
+            )
+        ).scalar_one_or_none()
+        if tenant is None:
+            raise CliError(f"tenant {ns.tenant!r} not found")
+
+        existing = (
+            await session.execute(
+                select(Membership).where(
+                    Membership.user_id == user.id,
+                    Membership.tenant_id == tenant.id,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise CliError(
+                f"user {user.email} already has membership on {tenant.slug} "
+                f"(source={existing.source!r}, role={existing.role!r})"
+            )
+        m = Membership(
+            user_id=user.id,
+            tenant_id=tenant.id,
+            role=ns.role,
+            source="manual",
+        )
+        session.add(m)
+        await session.commit()
+        await session.refresh(m)
+    return (
+        f"granted role={ns.role} to {ns.user_email} on tenant {ns.tenant} "
+        f"(membership {m.id})"
+    )
+
+
+async def cmd_membership_revoke(ns: Any, sm: async_sessionmaker) -> str:
+    membership_id = UUID(ns.membership_id)
+    async with sm() as session:
+        m = await session.get(Membership, membership_id)
+        if m is None:
+            raise CliError(f"membership {membership_id} not found")
+        if m.source != "manual":
+            raise CliError(
+                f"membership {membership_id} has source={m.source!r}; "
+                "only manual memberships are revocable via the CLI"
+            )
+        await session.delete(m)
+        await session.commit()
+    return f"revoked membership {membership_id}"
+
+
+COMMANDS: dict[tuple[str, str], Any] = {
+    ("tenant", "create"): cmd_tenant_create,
+    ("tenant", "list"): cmd_tenant_list,
+    ("store", "create"): cmd_store_create,
+    ("store", "list"): cmd_store_list,
+    ("user", "list"): cmd_user_list,
+    ("membership", "grant"): cmd_membership_grant,
+    ("membership", "revoke"): cmd_membership_revoke,
+}
+
+
+def run_command(
+    cmd: tuple[str, str], ns: Any, sm: async_sessionmaker
+) -> int:
+    """Resolve and run a CLI subcommand. Returns the process exit code."""
+    handler = COMMANDS.get(cmd)
+    if handler is None:
+        print(f"unknown command: {' '.join(cmd)}", file=sys.stderr)
+        return 2
+    try:
+        output = asyncio.run(handler(ns, sm))
+    except CliError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if output:
+        print(output)
+    return 0
+
+
+__all__ = ["COMMANDS", "CliError", "run_command"]

--- a/stash_mcp/errors.py
+++ b/stash_mcp/errors.py
@@ -1,0 +1,211 @@
+"""RFC 7807 Problem Details for the auth/admin/per-store HTTP surface.
+
+New endpoints (``/auth/*``, ``/admin/*``, per-store ``/api/<t>/<s>/*``)
+raise the typed subclasses below; :func:`install_problem_handlers` wires
+a FastAPI exception handler that renders them with the
+``application/problem+json`` media type. Legacy auth-disabled ``/api/*``
+endpoints keep their existing ``{"detail": "..."}`` shape so older
+deployments aren't disturbed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+
+PROBLEM_MEDIA_TYPE = "application/problem+json"
+
+
+@dataclass(frozen=True)
+class Problem:
+    type: str
+    title: str
+    status: int
+    detail: str | None = None
+
+
+class StashError(Exception):
+    """Base class for typed errors that render as Problem Details.
+
+    Subclasses set a class-level ``problem`` attribute. Callers may pass a
+    per-instance ``detail`` and any number of ``extras`` keyword args that
+    are merged into the response body (used for things like
+    ``current_etag`` on 412s or ``required_scope`` on 403s).
+    """
+
+    problem: Problem
+
+    def __init__(self, detail: str | None = None, **extras: Any) -> None:
+        self.detail = detail
+        self.extras = extras
+        super().__init__(detail or self.problem.title)
+
+
+# --- Registry of standard problems -----------------------------------------
+
+class Unauthenticated(StashError):
+    problem = Problem(
+        "/problems/auth/unauthenticated", "Authentication required", 401
+    )
+
+
+class Forbidden(StashError):
+    problem = Problem("/problems/auth/forbidden", "Forbidden", 403)
+
+
+class ScopeRequired(StashError):
+    problem = Problem(
+        "/problems/auth/scope-required", "Insufficient scope", 403
+    )
+
+
+class ContentNotFound(StashError):
+    problem = Problem(
+        "/problems/content/not-found", "Content not found", 404
+    )
+
+
+class ETagMismatch(StashError):
+    problem = Problem(
+        "/problems/content/etag-mismatch",
+        "ETag mismatch on conditional write",
+        412,
+    )
+
+
+class StoreNotFound(StashError):
+    problem = Problem("/problems/store/not-found", "Store not found", 404)
+
+
+class StoreAlreadyExists(StashError):
+    problem = Problem(
+        "/problems/store/already-exists", "Store already exists", 409
+    )
+
+
+class StoreNotProvisioned(StashError):
+    problem = Problem(
+        "/problems/store/not-provisioned",
+        "Store has DB row but no on-disk repo",
+        500,
+    )
+
+
+class TenantNotFound(StashError):
+    problem = Problem("/problems/tenant/not-found", "Tenant not found", 404)
+
+
+class TenantAlreadyExists(StashError):
+    problem = Problem(
+        "/problems/tenant/already-exists", "Tenant already exists", 409
+    )
+
+
+class TenantHasStores(StashError):
+    problem = Problem(
+        "/problems/tenant/has-stores",
+        "Tenant cannot be deleted while it owns stores",
+        409,
+    )
+
+
+class UserNotFound(StashError):
+    problem = Problem("/problems/user/not-found", "User not found", 404)
+
+
+class TokenNotFound(StashError):
+    problem = Problem("/problems/token/not-found", "Token not found", 404)
+
+
+class MembershipNotFound(StashError):
+    problem = Problem(
+        "/problems/membership/not-found", "Membership not found", 404
+    )
+
+
+class MembershipExists(StashError):
+    problem = Problem(
+        "/problems/membership/exists", "Membership already exists", 409
+    )
+
+
+class ValidationError(StashError):
+    problem = Problem("/problems/validation", "Validation failed", 400)
+
+
+class ConfirmationRequired(StashError):
+    problem = Problem(
+        "/problems/confirmation-required",
+        "Destructive operation requires confirm=true",
+        400,
+    )
+
+
+def problem_response(
+    *, request: Request | None, err: StashError
+) -> JSONResponse:
+    """Render a :class:`StashError` as an ``application/problem+json``."""
+    p = err.problem
+    body: dict[str, Any] = {
+        "type": p.type,
+        "title": p.title,
+        "status": p.status,
+    }
+    if request is not None:
+        body["instance"] = request.url.path
+    detail = err.detail or p.detail
+    if detail:
+        body["detail"] = detail
+    if err.extras:
+        for k, v in err.extras.items():
+            if k not in body:
+                body[k] = v
+    headers: dict[str, str] = {}
+    if p.status == 401:
+        headers["WWW-Authenticate"] = 'Bearer realm="stash"'
+    return JSONResponse(
+        body,
+        status_code=p.status,
+        headers=headers,
+        media_type=PROBLEM_MEDIA_TYPE,
+    )
+
+
+def install_problem_handlers(app: FastAPI) -> None:
+    """Register the FastAPI exception handler for :class:`StashError`."""
+
+    @app.exception_handler(StashError)
+    async def _stash_error_handler(
+        request: Request, exc: StashError
+    ) -> JSONResponse:
+        return problem_response(request=request, err=exc)
+
+
+__all__ = [
+    "PROBLEM_MEDIA_TYPE",
+    "ConfirmationRequired",
+    "ContentNotFound",
+    "ETagMismatch",
+    "Forbidden",
+    "MembershipExists",
+    "MembershipNotFound",
+    "Problem",
+    "ScopeRequired",
+    "StashError",
+    "StoreAlreadyExists",
+    "StoreNotFound",
+    "StoreNotProvisioned",
+    "TenantAlreadyExists",
+    "TenantHasStores",
+    "TenantNotFound",
+    "TokenNotFound",
+    "Unauthenticated",
+    "UserNotFound",
+    "ValidationError",
+    "install_problem_handlers",
+    "problem_response",
+]

--- a/stash_mcp/main.py
+++ b/stash_mcp/main.py
@@ -249,7 +249,12 @@ def _create_auth_enabled_app() -> FastAPI:
     Search is disabled in auth mode for v1 — a single shared index
     would leak content across tenants. See spec 04 open questions.
     """
+    from starlette.middleware.sessions import SessionMiddleware
+
+    from .admin import router as admin_router
     from .api import USE_CURRENT_STORE as API_USE_CURRENT_STORE
+    from .auth.routes import router as auth_router
+    from .errors import install_problem_handlers
     from .mcp_server import USE_CURRENT_STORE as MCP_USE_CURRENT_STORE
     from .routing import StoreResolverMiddleware
 
@@ -278,6 +283,14 @@ def _create_auth_enabled_app() -> FastAPI:
             get_metrics().close()
 
     app = create_api(API_USE_CURRENT_STORE, lifespan=_auth_lifespan)
+
+    install_problem_handlers(app)
+
+    # /auth and /admin are mounted on the same FastAPI app so they share
+    # the auth middleware (added below); the store-resolver middleware
+    # has explicit pass-through prefixes for both.
+    app.include_router(auth_router)
+    app.include_router(admin_router)
 
     # Search endpoint shim: explicit 503 when a client asks for search
     # under auth mode, so it surfaces clearly rather than 404-ing.
@@ -339,6 +352,17 @@ def _create_auth_enabled_app() -> FastAPI:
         ),
     )
     app.add_middleware(StashAuthMiddleware, providers=auth_providers)
+    # authlib's redirect/callback dance uses ``request.session`` to carry
+    # the ``next`` URL across the IdP round-trip. Use a separate cookie
+    # name so it can't be confused with the Stash session cookie.
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=Config.SESSION_SECRET or "stash-oauth-state-dev",
+        session_cookie="stash_oauth_state",
+        max_age=600,
+        same_site="lax",
+        https_only=False,
+    )
     return app
 
 

--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -187,6 +187,61 @@ bodies then resolve the FS / git_backend from
 :func:`stash_mcp.routing.context.current_store` at call time."""
 
 
+# Role → effective scope set. Members can read+write; admins additionally
+# get the admin scope (reserved for future admin tools — none today).
+_ROLE_SCOPES: dict[str, frozenset[str]] = {
+    "admin": frozenset({"read", "write", "admin"}),
+    "member": frozenset({"read", "write"}),
+}
+
+
+def _principal_scopes(principal, tenant_id) -> frozenset[str]:
+    """Resolve the effective scope set for a principal on a given tenant.
+
+    - ``api_token`` principals: explicit scope list from the token row
+      (passed through ``Principal.claims['scopes']`` which is a comma-
+      separated string).
+    - ``oidc`` / ``session`` principals: derived from membership role on
+      ``tenant_id``.
+    """
+    if principal.auth_method == "api_token":
+        raw = principal.claims.get("scopes", "")
+        if not isinstance(raw, str):
+            return frozenset()
+        return frozenset(s for s in raw.split(",") if s)
+    role = principal.tenant_roles.get(tenant_id)
+    if role is None:
+        return frozenset()
+    return _ROLE_SCOPES.get(role, frozenset())
+
+
+def _enforce_tool_scope(tool_name: str, required_scope: str) -> None:
+    """Raise if the in-flight principal lacks ``required_scope``.
+
+    Imported here rather than at module top to avoid circular imports
+    between ``mcp_server`` and the ``auth.context`` /
+    ``routing.context`` modules.
+    """
+    from .auth.context import current_principal
+    from .auth.provider import AuthError
+    from .routing.context import current_store
+
+    principal = current_principal()
+    if principal is None:
+        raise AuthError(f"tool {tool_name!r}: authentication required")
+    store = current_store()
+    if store is None:
+        raise AuthError(
+            f"tool {tool_name!r}: no store context (request reached "
+            "tool body without store resolver)"
+        )
+    scopes = _principal_scopes(principal, store.tenant_id)
+    if required_scope not in scopes:
+        raise AuthError(
+            f"tool {tool_name!r}: scope {required_scope!r} required"
+        )
+
+
 def create_mcp_server(
     filesystem_or_resolver,
     search_engine=None,
@@ -249,9 +304,19 @@ def create_mcp_server(
     # Wrap mcp.tool() so every registered tool is automatically timed and
     # its outcome recorded in the metrics collector.  Using functools.wraps
     # preserves the original signature so FastMCP generates the correct schema.
+    #
+    # The wrapper also enforces per-tool scope when ``AUTH_ENABLED=True``:
+    # read tools require the ``read`` scope, write/transaction tools require
+    # ``write``. Scopes derive from membership role for cookie/JWT principals
+    # and from the explicit list on the api_tokens row for API-token
+    # principals.
     _original_mcp_tool = mcp.tool
 
-    def _instrumented_tool(*deco_args, **deco_kwargs):
+    def _instrumented_tool(*deco_args, required_scope: str | None = None, **deco_kwargs):
+        if required_scope is None:
+            annotations = deco_kwargs.get("annotations")
+            read_hint = getattr(annotations, "readOnlyHint", False)
+            required_scope = "read" if read_hint else "write"
         orig_decorator = _original_mcp_tool(*deco_args, **deco_kwargs)
 
         def patching_decorator(fn):
@@ -259,6 +324,8 @@ def create_mcp_server(
 
             @functools.wraps(fn)
             async def _tracked(*args, **kwargs):
+                if Config.AUTH_ENABLED:
+                    _enforce_tool_scope(tool_name, required_scope)
                 t0 = time.perf_counter()
                 try:
                     result = await fn(*args, **kwargs)

--- a/stash_mcp/ui.py
+++ b/stash_mcp/ui.py
@@ -776,6 +776,23 @@ def _page(
         )
 
     toolbar_right_items = ""
+    # When AUTH_ENABLED, show the logged-in user's display name and a
+    # Sign out link. Reads the principal from the contextvar set by
+    # StashAuthMiddleware. In legacy mode the contextvar is unset and we
+    # render nothing.
+    try:
+        from .auth.context import current_principal as _current_principal
+
+        _p = _current_principal()
+    except Exception:  # pragma: no cover — defensive only
+        _p = None
+    if _p is not None:
+        toolbar_right_items += (
+            f'<span class="user-chip" title="{html.escape(_p.email or "")}">'
+            f"{html.escape(_p.display_name or _p.email or 'signed in')}"
+            "</span>"
+            '<a class="signout-link" href="/auth/logout">Sign out</a>'
+        )
     toolbar_right_items += (
         f'<button class="panel-toggle" onclick="toggleSidebar()" '
         f'title="Toggle sidebar">{_icon("panel-left")}</button>'

--- a/tests/admin/conftest.py
+++ b/tests/admin/conftest.py
@@ -1,0 +1,182 @@
+"""Shared fixtures for the admin/auth-route test suites."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+from starlette.testclient import TestClient
+
+from stash_mcp.admin.routes import router as admin_router
+from stash_mcp.auth.context import (
+    reset_current_principal,
+    set_current_principal,
+)
+from stash_mcp.auth.principal import Principal
+from stash_mcp.auth.routes import router as auth_router
+from stash_mcp.config import Config
+from stash_mcp.db import engine as engine_mod
+from stash_mcp.db import session as session_mod
+from stash_mcp.db.models import Base, Tenant
+from stash_mcp.errors import install_problem_handlers
+from stash_mcp.stores import registry as registry_mod
+
+
+def _enable_sqlite_fks(engine: AsyncEngine) -> None:
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_pragma(dbapi_connection, _record):  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+@pytest.fixture
+async def auth_db(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[
+    async_sessionmaker[AsyncSession]
+]:
+    test_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    _enable_sqlite_fks(test_engine)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    test_sm = async_sessionmaker(
+        test_engine, expire_on_commit=False, class_=AsyncSession
+    )
+    monkeypatch.setattr(engine_mod, "_engine", test_engine, raising=False)
+    monkeypatch.setattr(session_mod, "_sessionmaker", test_sm, raising=False)
+    try:
+        yield test_sm
+    finally:
+        await test_engine.dispose()
+        monkeypatch.setattr(engine_mod, "_engine", None, raising=False)
+        monkeypatch.setattr(session_mod, "_sessionmaker", None, raising=False)
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    monkeypatch.setattr(Config, "READ_ONLY", False, raising=False)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_singleton(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+    yield
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _auth_config_defaults(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        Config, "AUTH_TOKEN_HMAC_KEYS", ["test-key-0"], raising=False
+    )
+    monkeypatch.setattr(Config, "SESSION_SECRET", "test-secret", raising=False)
+    monkeypatch.setattr(
+        Config, "SESSION_MAX_AGE_SECONDS", 3600, raising=False
+    )
+    monkeypatch.setattr(Config, "OIDC_GROUPS_CLAIM", "groups", raising=False)
+    monkeypatch.setattr(
+        Config, "OIDC_ADMIN_GROUP", "stash-admins", raising=False
+    )
+    yield
+
+
+async def _ensure_default_tenant(
+    sm: async_sessionmaker[AsyncSession],
+) -> Tenant:
+    async with sm() as session:
+        from sqlalchemy import select
+
+        existing = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == "default")
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return existing
+        tenant = Tenant(slug="default", display_name="Default tenant")
+        session.add(tenant)
+        await session.commit()
+        await session.refresh(tenant)
+        return tenant
+
+
+def _principal(
+    *,
+    tenant_roles: dict[UUID, str],
+    auth_method: str = "session",
+    user_id: UUID | None = None,
+    claims: dict | None = None,
+) -> Principal:
+    return Principal(
+        user_id=user_id or uuid4(),
+        oidc_sub="test-sub",
+        email="test@example.com",
+        display_name="Test",
+        auth_method=auth_method,  # type: ignore[arg-type]
+        tenant_roles=tenant_roles,  # type: ignore[arg-type]
+        claims=claims or {},
+    )
+
+
+class _PrincipalInjector:
+    """ASGI middleware that pins a principal for every request."""
+
+    def __init__(self, app, principal: Principal | None):
+        self.app = app
+        self.principal = principal
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or self.principal is None:
+            await self.app(scope, receive, send)
+            return
+        token = set_current_principal(self.principal)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            reset_current_principal(token)
+
+
+def make_admin_app(principal: Principal | None):
+    """Build a minimal FastAPI app with the /auth and /admin routers and
+    the given fixed principal."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    install_problem_handlers(app)
+    app.include_router(auth_router)
+    app.include_router(admin_router)
+    asgi = _PrincipalInjector(app, principal)
+    return asgi
+
+
+def make_client(principal: Principal | None) -> TestClient:
+    return TestClient(make_admin_app(principal))
+
+
+__all__ = [
+    "auth_db",
+    "content_dir",
+    "make_admin_app",
+    "make_client",
+    "_PrincipalInjector",
+    "_principal",
+    "_ensure_default_tenant",
+]

--- a/tests/admin/test_admin_routes.py
+++ b/tests/admin/test_admin_routes.py
@@ -1,0 +1,394 @@
+"""End-to-end tests for ``/admin/*``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from stash_mcp.db.models import (
+    ApiToken,
+    AuditEvent,
+    Membership,
+    Store,
+    Tenant,
+    User,
+)
+from stash_mcp.errors import PROBLEM_MEDIA_TYPE
+
+from .conftest import (
+    _ensure_default_tenant,
+    _principal,
+    make_client,
+)
+
+
+async def _make_user(
+    auth_db: async_sessionmaker, *, email: str
+) -> User:
+    async with auth_db() as session:
+        user = User(oidc_sub=email, email=email, display_name=email)
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest.fixture
+async def admin_principal(auth_db: async_sessionmaker):
+    tenant = await _ensure_default_tenant(auth_db)
+    user = await _make_user(auth_db, email="admin@x")
+    return _principal(tenant_roles={tenant.id: "admin"}, user_id=user.id)
+
+
+@pytest.fixture
+async def member_principal(auth_db: async_sessionmaker):
+    tenant = await _ensure_default_tenant(auth_db)
+    user = await _make_user(auth_db, email="member@x")
+    return _principal(tenant_roles={tenant.id: "member"}, user_id=user.id)
+
+
+async def test_non_admin_blocked(auth_db, content_dir: Path, member_principal):
+    client = make_client(member_principal)
+    resp = client.get("/admin/tenants")
+    assert resp.status_code == 403
+    assert resp.headers["content-type"].startswith(PROBLEM_MEDIA_TYPE)
+    assert resp.json()["type"] == "/problems/auth/forbidden"
+
+
+async def test_unauthenticated_blocked(auth_db, content_dir: Path):
+    await _ensure_default_tenant(auth_db)
+    client = make_client(None)
+    resp = client.get("/admin/tenants")
+    assert resp.status_code == 401
+    assert resp.json()["type"] == "/problems/auth/unauthenticated"
+
+
+async def test_tenant_crud_round_trip(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+
+    # Create
+    resp = client.post(
+        "/admin/tenants",
+        json={"slug": "acme", "display_name": "Acme"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    tenant_id = body["id"]
+    assert body["slug"] == "acme"
+
+    # List
+    resp = client.get("/admin/tenants")
+    assert resp.status_code == 200
+    slugs = {t["slug"] for t in resp.json()}
+    assert {"acme", "default"} <= slugs
+
+    # Get
+    resp = client.get(f"/admin/tenants/{tenant_id}")
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Acme"
+
+    # Rename
+    resp = client.patch(
+        f"/admin/tenants/{tenant_id}", json={"display_name": "Acme Inc."}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Acme Inc."
+
+    # Delete (no stores yet — should succeed)
+    resp = client.delete(f"/admin/tenants/{tenant_id}")
+    assert resp.status_code == 204
+
+    # Audit row exists.
+    async with auth_db() as session:
+        events = (
+            (await session.execute(select(AuditEvent)))
+            .scalars()
+            .all()
+        )
+    actions = {e.action for e in events}
+    assert {"tenant.created", "tenant.renamed", "tenant.deleted"} <= actions
+
+
+async def test_tenant_create_duplicate_slug_conflicts(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    client.post("/admin/tenants", json={"slug": "acme", "display_name": "A"})
+    resp = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "B"}
+    )
+    assert resp.status_code == 409
+    assert resp.json()["type"] == "/problems/tenant/already-exists"
+
+
+async def test_store_provisioning_creates_on_disk_repo(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    tenant = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "Acme"}
+    ).json()
+
+    resp = client.post(
+        f"/admin/tenants/{tenant['id']}/stores",
+        json={"slug": "docs", "display_name": "Docs"},
+    )
+    assert resp.status_code == 201, resp.text
+    store = resp.json()
+    assert store["slug"] == "docs"
+
+    on_disk = content_dir / tenant["id"] / "docs"
+    assert on_disk.exists()
+    assert (on_disk / ".git").exists()
+
+
+async def test_store_delete_requires_confirm(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    tenant = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "A"}
+    ).json()
+    client.post(
+        f"/admin/tenants/{tenant['id']}/stores",
+        json={"slug": "docs", "display_name": "Docs"},
+    )
+    # No confirm flag → 400
+    resp = client.delete(f"/admin/tenants/{tenant['id']}/stores/docs")
+    assert resp.status_code == 400
+    assert resp.json()["type"] == "/problems/confirmation-required"
+    # On disk still there.
+    assert (content_dir / tenant["id"] / "docs").exists()
+
+    # With confirm=true → 204 + removed.
+    resp = client.delete(
+        f"/admin/tenants/{tenant['id']}/stores/docs?confirm=true"
+    )
+    assert resp.status_code == 204
+    assert not (content_dir / tenant["id"] / "docs").exists()
+
+    async with auth_db() as session:
+        rows = (
+            (await session.execute(select(Store))).scalars().all()
+        )
+    assert rows == []
+
+
+async def test_manual_membership_grant_survives_oidc_resync(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+
+    # Create a tenant + a user the membership will target.
+    tenant = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "A"}
+    ).json()
+
+    async with auth_db() as session:
+        user = User(oidc_sub="alice", email="a@x", display_name="Alice")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        uid = str(user.id)
+
+    resp = client.post(
+        "/admin/memberships",
+        json={"user_id": uid, "tenant_id": tenant["id"], "role": "member"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["source"] == "manual"
+
+    # Simulate an OIDC group resync. The "manual wins" precedence is
+    # exercised in tests/auth/; here we just verify the manual row stays
+    # after running the same upsert flow.
+    from stash_mcp.auth.users import upsert_user_and_memberships
+
+    async with auth_db() as session:
+        await upsert_user_and_memberships(
+            session,
+            {"sub": "alice", "email": "a@x", "name": "Alice", "groups": []},
+        )
+        await session.commit()
+        rows = (
+            (
+                await session.execute(
+                    select(Membership).where(Membership.user_id == user.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {m.source for m in rows} == {"manual"}
+
+
+async def test_membership_grant_then_revoke(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    tenant = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "A"}
+    ).json()
+    async with auth_db() as session:
+        user = User(oidc_sub="bob", email="b@x", display_name="Bob")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        uid = str(user.id)
+
+    grant = client.post(
+        "/admin/memberships",
+        json={"user_id": uid, "tenant_id": tenant["id"], "role": "admin"},
+    ).json()
+    assert grant["role"] == "admin"
+
+    # Duplicate grant 409s
+    again = client.post(
+        "/admin/memberships",
+        json={"user_id": uid, "tenant_id": tenant["id"], "role": "admin"},
+    )
+    assert again.status_code == 409
+
+    revoke = client.delete(f"/admin/memberships/{grant['id']}")
+    assert revoke.status_code == 204
+    async with auth_db() as session:
+        rows = (
+            (await session.execute(select(Membership)))
+            .scalars()
+            .all()
+        )
+    assert all(r.id != grant["id"] for r in rows)
+
+
+async def test_user_list_and_delete_cascades(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    async with auth_db() as session:
+        user = User(oidc_sub="carol", email="c@x", display_name="Carol")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        token = ApiToken(
+            user_id=user.id,
+            token_hash="dummy-hash",
+            key_version=0,
+            name="pat",
+            scopes="read",
+        )
+        session.add(token)
+        await session.commit()
+        uid = str(user.id)
+
+    listing = client.get("/admin/users").json()
+    assert any(u["email"] == "c@x" for u in listing)
+
+    resp = client.delete(f"/admin/users/{uid}")
+    assert resp.status_code == 204
+
+    async with auth_db() as session:
+        # User and its tokens are gone (cascade) — but we don't depend on
+        # exact cascade semantics in SQLite, just confirm the user is gone.
+        user_row = (
+            await session.execute(
+                select(User).where(User.email == "c@x")
+            )
+        ).scalar_one_or_none()
+        assert user_row is None
+
+
+async def test_tenant_delete_blocked_when_stores_remain(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    tenant = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "A"}
+    ).json()
+    client.post(
+        f"/admin/tenants/{tenant['id']}/stores",
+        json={"slug": "docs", "display_name": "Docs"},
+    )
+    resp = client.delete(f"/admin/tenants/{tenant['id']}")
+    assert resp.status_code == 409
+    assert resp.json()["type"] == "/problems/tenant/has-stores"
+
+
+async def test_default_tenant_missing_surfaces_as_404(
+    auth_db, content_dir: Path
+):
+    # No default tenant created — admin dependency should surface that
+    # as a TenantNotFound rather than a misleading 403.
+    from uuid import uuid4
+
+    from stash_mcp.auth.principal import Principal
+
+    p = Principal(
+        user_id=uuid4(),
+        oidc_sub="ghost",
+        email="g@x",
+        display_name="Ghost",
+        auth_method="session",
+        tenant_roles={},
+    )
+    client = make_client(p)
+    resp = client.get("/admin/tenants")
+    assert resp.status_code == 404
+    assert resp.json()["type"] == "/problems/tenant/not-found"
+
+
+async def test_admin_audit_rows_include_tenant_id(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    tenant = client.post(
+        "/admin/tenants", json={"slug": "acme", "display_name": "A"}
+    ).json()
+    client.post(
+        f"/admin/tenants/{tenant['id']}/stores",
+        json={"slug": "docs", "display_name": "D"},
+    )
+
+    async with auth_db() as session:
+        events = (
+            (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.action.in_(
+                            ("tenant.created", "store.provisioned")
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_action = {e.action: e for e in events}
+    assert str(by_action["tenant.created"].tenant_id) == tenant["id"]
+    assert str(by_action["store.provisioned"].tenant_id) == tenant["id"]
+    # actor_user_id is the admin principal.
+    assert (
+        by_action["tenant.created"].actor_user_id
+        == admin_principal.user_id
+    )
+
+
+async def test_default_tenant_unaffected_by_acme_tenant_ops(
+    auth_db, content_dir: Path, admin_principal
+):
+    client = make_client(admin_principal)
+    async with auth_db() as session:
+        default = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == "default")
+            )
+        ).scalar_one()
+        default_id = str(default.id)
+
+    client.post("/admin/tenants", json={"slug": "acme", "display_name": "A"})
+    resp = client.get(f"/admin/tenants/{default_id}")
+    assert resp.status_code == 200

--- a/tests/admin/test_oidc_routes.py
+++ b/tests/admin/test_oidc_routes.py
@@ -1,0 +1,200 @@
+"""End-to-end tests for ``/auth/login`` and ``/auth/callback``.
+
+We don't stand up a real IdP — instead we monkey-patch ``get_oauth`` to
+return a stub whose ``authorize_redirect`` records the call and whose
+``authorize_access_token`` returns canned claims.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.responses import RedirectResponse
+from starlette.testclient import TestClient
+
+from stash_mcp.auth import routes as auth_routes
+from stash_mcp.auth.routes import router as auth_router
+from stash_mcp.config import Config
+from stash_mcp.db.models import Membership, User
+from stash_mcp.errors import install_problem_handlers
+
+
+def _build_app(monkeypatch: pytest.MonkeyPatch, claims_for_callback: dict):
+    """Build a FastAPI app with a stubbed OAuth client.
+
+    ``/auth/login`` returns a fake 302 to a sentinel IdP URL; the
+    callback resolves ``claims_for_callback`` as the userinfo. Tests
+    cover both ends independently.
+    """
+    app = FastAPI()
+    install_problem_handlers(app)
+    app.include_router(auth_router)
+    app.add_middleware(
+        SessionMiddleware, secret_key="test-secret", session_cookie="oauth"
+    )
+
+    stub = type("OAuth", (), {})()
+    idp = type("IdP", (), {})()
+
+    async def _authorize_redirect(request, redirect_uri):
+        return RedirectResponse(
+            url=f"https://idp.example/authorize?cb={redirect_uri}",
+            status_code=302,
+        )
+
+    async def _authorize_access_token(request):
+        return {"userinfo": claims_for_callback}
+
+    idp.authorize_redirect = _authorize_redirect
+    idp.authorize_access_token = _authorize_access_token
+    stub.idp = idp
+
+    monkeypatch.setattr(auth_routes, "get_oauth", lambda: stub)
+    monkeypatch.setattr(
+        auth_routes, "_is_local_dev", lambda: True
+    )  # let cookies skip Secure flag for TestClient
+    return app
+
+
+async def test_login_redirects_to_idp(
+    auth_db, content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    app = _build_app(monkeypatch, claims_for_callback={})
+    client = TestClient(app, follow_redirects=False)
+    resp = client.get("/auth/login?next=/ui/foo")
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert location.startswith("https://idp.example/authorize")
+    assert "cb=" in location
+    # callback URL is encoded in the redirect.
+    assert "auth/callback" in location
+
+
+async def test_callback_creates_user_and_sets_cookie(
+    auth_db: async_sessionmaker,
+    content_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    claims = {
+        "sub": "alice-sub",
+        "email": "alice@x",
+        "name": "Alice",
+        "groups": ["stash-admins"],
+    }
+    app = _build_app(monkeypatch, claims_for_callback=claims)
+    client = TestClient(app, follow_redirects=False)
+
+    # Visit /login first to set the session 'next' value.
+    client.get("/auth/login?next=/ui/landing")
+    resp = client.get("/auth/callback")
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/ui/landing"
+    cookies = resp.headers.get_list("set-cookie")
+    assert any(Config.SESSION_COOKIE_NAME in c for c in cookies)
+
+    async with auth_db() as session:
+        user = (
+            await session.execute(
+                select(User).where(User.oidc_sub == "alice-sub")
+            )
+        ).scalar_one_or_none()
+        assert user is not None
+        assert user.email == "alice@x"
+
+        # Admin group → admin membership on the default tenant.
+        memberships = (
+            (
+                await session.execute(
+                    select(Membership).where(Membership.user_id == user.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert any(m.role == "admin" for m in memberships)
+
+
+async def test_callback_refreshes_existing_user(
+    auth_db: async_sessionmaker,
+    content_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Pre-seed user with stale display name.
+    async with auth_db() as session:
+        user = User(oidc_sub="alice-sub", email="old@x", display_name="Old")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        original_id = user.id
+
+    claims = {
+        "sub": "alice-sub",
+        "email": "alice@x",
+        "name": "Alice Updated",
+        "groups": [],
+    }
+    app = _build_app(monkeypatch, claims_for_callback=claims)
+    client = TestClient(app, follow_redirects=False)
+    client.get("/auth/login")
+    resp = client.get("/auth/callback")
+    assert resp.status_code == 302
+
+    async with auth_db() as session:
+        refreshed = (
+            await session.execute(
+                select(User).where(User.oidc_sub == "alice-sub")
+            )
+        ).scalar_one()
+    assert refreshed.id == original_id  # same row
+    assert refreshed.email == "alice@x"
+    assert refreshed.display_name == "Alice Updated"
+
+
+async def test_callback_rejects_claims_without_sub(
+    auth_db, content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    app = _build_app(monkeypatch, claims_for_callback={"email": "x@y"})
+    client = TestClient(app, follow_redirects=False)
+    client.get("/auth/login")
+    resp = client.get("/auth/callback")
+    assert resp.status_code == 400
+    assert resp.json()["type"] == "/problems/validation"
+
+
+async def test_logout_clears_cookie(
+    auth_db, content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    app = _build_app(
+        monkeypatch,
+        claims_for_callback={"sub": "x", "email": "x@y", "name": "X"},
+    )
+    client = TestClient(app, follow_redirects=False)
+    resp = client.get("/auth/logout")
+    assert resp.status_code == 302
+    cookies = resp.headers.get_list("set-cookie")
+    assert any(
+        Config.SESSION_COOKIE_NAME in c and "Max-Age=0" in c
+        for c in cookies
+    )
+
+
+async def test_callback_redirects_safely_for_external_next(
+    auth_db, content_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An attacker-controlled ``next`` parameter must never escape the
+    server. We accept only paths that start with ``/``."""
+    app = _build_app(
+        monkeypatch,
+        claims_for_callback={"sub": "x", "email": "x@y", "name": "X"},
+    )
+    client = TestClient(app, follow_redirects=False)
+    # Inject an absolute URL into the session next.
+    client.get("/auth/login?next=https://evil.example")
+    resp = client.get("/auth/callback")
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/ui"

--- a/tests/admin/test_problem_details.py
+++ b/tests/admin/test_problem_details.py
@@ -1,0 +1,107 @@
+"""Smoke coverage for the Problem Details exception handler + each
+standard :class:`StashError` subclass."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from stash_mcp.errors import (
+    PROBLEM_MEDIA_TYPE,
+    ConfirmationRequired,
+    ContentNotFound,
+    ETagMismatch,
+    Forbidden,
+    ScopeRequired,
+    StoreAlreadyExists,
+    StoreNotFound,
+    StoreNotProvisioned,
+    TenantAlreadyExists,
+    TenantHasStores,
+    TenantNotFound,
+    TokenNotFound,
+    Unauthenticated,
+    UserNotFound,
+    ValidationError,
+    install_problem_handlers,
+)
+
+
+def _build_app(err_factory):
+    app = FastAPI()
+    install_problem_handlers(app)
+
+    @app.get("/boom")
+    async def boom():
+        raise err_factory()
+
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "factory, status, type_id, title",
+    [
+        (lambda: Unauthenticated("login required"), 401,
+         "/problems/auth/unauthenticated", "Authentication required"),
+        (lambda: Forbidden(), 403,
+         "/problems/auth/forbidden", "Forbidden"),
+        (lambda: ScopeRequired(required_scope="write"), 403,
+         "/problems/auth/scope-required", "Insufficient scope"),
+        (lambda: ContentNotFound("missing"), 404,
+         "/problems/content/not-found", "Content not found"),
+        (lambda: ETagMismatch(current_etag='"abc"'), 412,
+         "/problems/content/etag-mismatch",
+         "ETag mismatch on conditional write"),
+        (lambda: StoreNotFound(), 404,
+         "/problems/store/not-found", "Store not found"),
+        (lambda: StoreAlreadyExists(), 409,
+         "/problems/store/already-exists", "Store already exists"),
+        (lambda: StoreNotProvisioned("on-disk gone"), 500,
+         "/problems/store/not-provisioned",
+         "Store has DB row but no on-disk repo"),
+        (lambda: TenantNotFound(), 404,
+         "/problems/tenant/not-found", "Tenant not found"),
+        (lambda: TenantAlreadyExists(), 409,
+         "/problems/tenant/already-exists", "Tenant already exists"),
+        (lambda: TenantHasStores(), 409,
+         "/problems/tenant/has-stores",
+         "Tenant cannot be deleted while it owns stores"),
+        (lambda: UserNotFound(), 404,
+         "/problems/user/not-found", "User not found"),
+        (lambda: TokenNotFound(), 404,
+         "/problems/token/not-found", "Token not found"),
+        (lambda: ValidationError(errors=["bad"]), 400,
+         "/problems/validation", "Validation failed"),
+        (lambda: ConfirmationRequired(), 400,
+         "/problems/confirmation-required",
+         "Destructive operation requires confirm=true"),
+    ],
+)
+def test_problem_renders_standard_fields(factory, status, type_id, title):
+    client = _build_app(factory)
+    resp = client.get("/boom")
+    assert resp.status_code == status
+    assert resp.headers["content-type"].startswith(PROBLEM_MEDIA_TYPE)
+    body = resp.json()
+    assert body["type"] == type_id
+    assert body["title"] == title
+    assert body["status"] == status
+    assert body["instance"] == "/boom"
+
+
+def test_extras_flow_into_response_body():
+    client = _build_app(
+        lambda: ETagMismatch(detail="stale write", current_etag='"deadbeef"')
+    )
+    resp = client.get("/boom")
+    body = resp.json()
+    assert body["detail"] == "stale write"
+    assert body["current_etag"] == '"deadbeef"'
+
+
+def test_401_sets_www_authenticate():
+    client = _build_app(lambda: Unauthenticated())
+    resp = client.get("/boom")
+    assert resp.status_code == 401
+    assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")

--- a/tests/admin/test_token_routes.py
+++ b/tests/admin/test_token_routes.py
@@ -1,0 +1,234 @@
+"""End-to-end tests for ``/auth/tokens``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from stash_mcp.auth.principal import Principal
+from stash_mcp.auth.tokens import hash_token
+from stash_mcp.db.models import ApiToken, AuditEvent, User
+
+from .conftest import _principal, make_client
+
+
+async def _make_session_user(
+    auth_db: async_sessionmaker, *, email: str = "alice@x"
+) -> User:
+    async with auth_db() as session:
+        user = User(oidc_sub=email, email=email, display_name=email)
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest.fixture
+async def session_principal(auth_db: async_sessionmaker):
+    user = await _make_session_user(auth_db)
+    return _principal(
+        tenant_roles={},
+        auth_method="session",
+        user_id=user.id,
+    )
+
+
+async def test_unauthenticated_blocked(auth_db, content_dir: Path):
+    client = make_client(None)
+    resp = client.get("/auth/tokens")
+    assert resp.status_code == 401
+
+
+async def test_token_callers_cannot_mint(
+    auth_db, content_dir: Path
+):
+    user = await _make_session_user(auth_db, email="token-caller@x")
+    p = Principal(
+        user_id=user.id,
+        oidc_sub="token-caller@x",
+        email="token-caller@x",
+        display_name="t",
+        auth_method="api_token",
+        tenant_roles={},
+        claims={"scopes": "read,write"},
+    )
+    client = make_client(p)
+    resp = client.post("/auth/tokens", json={"name": "x"})
+    assert resp.status_code == 403
+    assert resp.json()["type"] == "/problems/auth/forbidden"
+
+
+async def test_jwt_callers_cannot_mint(auth_db, content_dir: Path):
+    user = await _make_session_user(auth_db, email="jwt@x")
+    p = Principal(
+        user_id=user.id,
+        oidc_sub="jwt@x",
+        email="jwt@x",
+        display_name="j",
+        auth_method="oidc",
+        tenant_roles={},
+    )
+    client = make_client(p)
+    resp = client.post("/auth/tokens", json={"name": "x"})
+    assert resp.status_code == 403
+
+
+async def test_session_caller_mints_token(
+    auth_db, content_dir: Path, session_principal
+):
+    client = make_client(session_principal)
+    resp = client.post(
+        "/auth/tokens",
+        json={"name": "ci", "scopes": ["read", "write"]},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "ci"
+    assert body["scopes"] == ["read", "write"]
+    assert body["token"].startswith("stash_pat_")
+    plaintext = body["token"]
+
+    # The token row exists with the correct hash.
+    async with auth_db() as session:
+        rows = (
+            (await session.execute(select(ApiToken)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].name == "ci"
+    assert rows[0].token_hash == hash_token(plaintext, key="test-key-0")
+    assert rows[0].key_version == 0
+
+    # Audit row.
+    async with auth_db() as session:
+        events = (
+            (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.action == "token.issued"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(events) == 1
+
+
+async def test_list_excludes_secret(
+    auth_db, content_dir: Path, session_principal
+):
+    client = make_client(session_principal)
+    client.post("/auth/tokens", json={"name": "t1"})
+    resp = client.get("/auth/tokens")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert "token" not in body[0]
+    assert body[0]["name"] == "t1"
+
+
+async def test_invalid_scope_rejected(
+    auth_db, content_dir: Path, session_principal
+):
+    client = make_client(session_principal)
+    resp = client.post(
+        "/auth/tokens",
+        json={"name": "t", "scopes": ["read", "exfiltrate"]},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["type"] == "/problems/validation"
+
+
+async def test_revoke_token(
+    auth_db, content_dir: Path, session_principal
+):
+    client = make_client(session_principal)
+    created = client.post("/auth/tokens", json={"name": "t1"}).json()
+    revoke = client.delete(f"/auth/tokens/{created['id']}")
+    assert revoke.status_code == 204
+    # Listing without include_revoked excludes it.
+    listed = client.get("/auth/tokens").json()
+    assert listed == []
+    # With include_revoked it reappears with a revoked_at.
+    listed = client.get("/auth/tokens?include_revoked=true").json()
+    assert len(listed) == 1
+    assert listed[0]["revoked_at"] is not None
+
+    async with auth_db() as session:
+        events = (
+            (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.action.in_(("token.issued", "token.revoked"))
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    actions = {e.action for e in events}
+    assert actions == {"token.issued", "token.revoked"}
+
+
+async def test_revoke_unknown_token_404(
+    auth_db, content_dir: Path, session_principal
+):
+    client = make_client(session_principal)
+    resp = client.delete(f"/auth/tokens/{uuid4()}")
+    assert resp.status_code == 404
+    assert resp.json()["type"] == "/problems/token/not-found"
+
+
+async def test_revoke_other_users_token_404(
+    auth_db, content_dir: Path, session_principal
+):
+    # A second user mints a token. The first user must not be able to
+    # revoke it — the lookup is scoped by user_id so they see a 404.
+    other = await _make_session_user(auth_db, email="bob@x")
+    async with auth_db() as session:
+        row = ApiToken(
+            user_id=other.id,
+            token_hash="h",
+            key_version=0,
+            name="t",
+            scopes="read",
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        target_id = row.id
+
+    client = make_client(session_principal)
+    resp = client.delete(f"/auth/tokens/{target_id}")
+    assert resp.status_code == 404
+
+
+async def test_revoke_idempotent(
+    auth_db, content_dir: Path, session_principal
+):
+    client = make_client(session_principal)
+    created = client.post("/auth/tokens", json={"name": "t1"}).json()
+    first = client.delete(f"/auth/tokens/{created['id']}")
+    second = client.delete(f"/auth/tokens/{created['id']}")
+    assert first.status_code == 204
+    assert second.status_code == 204
+    # Only one audit row.
+    async with auth_db() as session:
+        events = (
+            (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.action == "token.revoked"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(events) == 1

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,73 @@
+"""Fixtures for ``tests/cli`` — in-memory SQLite + sessionmaker singleton
+override mirroring ``tests/admin/conftest.py``."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from stash_mcp.config import Config
+from stash_mcp.db import engine as engine_mod
+from stash_mcp.db import session as session_mod
+from stash_mcp.db.models import Base
+from stash_mcp.stores import registry as registry_mod
+
+
+def _enable_sqlite_fks(engine: AsyncEngine) -> None:
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_pragma(dbapi_connection, _record):  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+@pytest.fixture
+async def auth_db(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[
+    async_sessionmaker[AsyncSession]
+]:
+    test_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    _enable_sqlite_fks(test_engine)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    test_sm = async_sessionmaker(
+        test_engine, expire_on_commit=False, class_=AsyncSession
+    )
+    monkeypatch.setattr(engine_mod, "_engine", test_engine, raising=False)
+    monkeypatch.setattr(session_mod, "_sessionmaker", test_sm, raising=False)
+    try:
+        yield test_sm
+    finally:
+        await test_engine.dispose()
+        monkeypatch.setattr(engine_mod, "_engine", None, raising=False)
+        monkeypatch.setattr(session_mod, "_sessionmaker", None, raising=False)
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    monkeypatch.setattr(Config, "READ_ONLY", False, raising=False)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_singleton(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+    yield
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -1,0 +1,209 @@
+"""Round-trip tests for the ``stash-mcp-cli`` subcommands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from stash_mcp.cli.__main__ import _build_parser
+from stash_mcp.cli.commands import (
+    cmd_membership_grant,
+    cmd_membership_revoke,
+    cmd_store_create,
+    cmd_store_list,
+    cmd_tenant_create,
+    cmd_tenant_list,
+    cmd_user_list,
+)
+from stash_mcp.db.models import Membership, Tenant, User
+
+
+def _parse(argv: list[str]):
+    parser = _build_parser()
+    return parser.parse_args(argv)
+
+
+async def test_tenant_create_and_list(
+    auth_db: async_sessionmaker, content_dir: Path
+):
+    ns = _parse(["tenant", "create", "--slug", "acme", "--name", "Acme Inc"])
+    output = await cmd_tenant_create(ns, auth_db)
+    assert "acme" in output
+
+    out = await cmd_tenant_list(_parse(["tenant", "list"]), auth_db)
+    assert "acme" in out
+
+
+async def test_tenant_create_duplicate_raises(
+    auth_db, content_dir: Path
+):
+    from stash_mcp.cli.commands import CliError
+
+    ns = _parse(["tenant", "create", "--slug", "acme", "--name", "A"])
+    await cmd_tenant_create(ns, auth_db)
+    with pytest.raises(CliError):
+        await cmd_tenant_create(ns, auth_db)
+
+
+async def test_store_create_provisions_repo(
+    auth_db, content_dir: Path
+):
+    await cmd_tenant_create(
+        _parse(["tenant", "create", "--slug", "acme", "--name", "A"]), auth_db
+    )
+    ns = _parse(
+        ["store", "create", "--tenant", "acme", "--slug", "docs"]
+    )
+    output = await cmd_store_create(ns, auth_db)
+    assert "docs" in output
+
+    async with auth_db() as session:
+        tenant = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == "acme")
+            )
+        ).scalar_one()
+    on_disk = content_dir / str(tenant.id) / "docs"
+    assert on_disk.exists()
+    assert (on_disk / ".git").exists()
+
+
+async def test_store_list(auth_db, content_dir: Path):
+    await cmd_tenant_create(
+        _parse(["tenant", "create", "--slug", "acme", "--name", "A"]), auth_db
+    )
+    await cmd_store_create(
+        _parse(
+            ["store", "create", "--tenant", "acme", "--slug", "docs"]
+        ),
+        auth_db,
+    )
+    out = await cmd_store_list(
+        _parse(["store", "list", "--tenant", "acme"]), auth_db
+    )
+    assert "docs" in out
+
+
+async def test_store_create_missing_tenant(
+    auth_db, content_dir: Path
+):
+    from stash_mcp.cli.commands import CliError
+
+    ns = _parse(
+        ["store", "create", "--tenant", "ghost", "--slug", "docs"]
+    )
+    with pytest.raises(CliError):
+        await cmd_store_create(ns, auth_db)
+
+
+async def test_user_list_returns_empty_when_no_users(
+    auth_db, content_dir: Path
+):
+    out = await cmd_user_list(_parse(["user", "list"]), auth_db)
+    assert "(no users)" in out
+
+
+async def test_membership_grant_and_revoke(
+    auth_db, content_dir: Path
+):
+    await cmd_tenant_create(
+        _parse(["tenant", "create", "--slug", "acme", "--name", "A"]), auth_db
+    )
+    async with auth_db() as session:
+        user = User(oidc_sub="alice", email="alice@example.com", display_name="A")
+        session.add(user)
+        await session.commit()
+
+    ns = _parse(
+        [
+            "membership",
+            "grant",
+            "--user-email",
+            "alice@example.com",
+            "--tenant",
+            "acme",
+            "--role",
+            "member",
+        ]
+    )
+    output = await cmd_membership_grant(ns, auth_db)
+    assert "alice@example.com" in output
+
+    async with auth_db() as session:
+        row = (
+            await session.execute(select(Membership))
+        ).scalar_one()
+    assert row.role == "member"
+    assert row.source == "manual"
+
+    revoke_ns = _parse(["membership", "revoke", str(row.id)])
+    out = await cmd_membership_revoke(revoke_ns, auth_db)
+    assert "revoked" in out
+
+    async with auth_db() as session:
+        remaining = (
+            (await session.execute(select(Membership))).scalars().all()
+        )
+    assert remaining == []
+
+
+async def test_membership_grant_unknown_user(
+    auth_db, content_dir: Path
+):
+    from stash_mcp.cli.commands import CliError
+
+    await cmd_tenant_create(
+        _parse(["tenant", "create", "--slug", "acme", "--name", "A"]), auth_db
+    )
+    ns = _parse(
+        [
+            "membership",
+            "grant",
+            "--user-email",
+            "ghost@example.com",
+            "--tenant",
+            "acme",
+            "--role",
+            "member",
+        ]
+    )
+    with pytest.raises(CliError):
+        await cmd_membership_grant(ns, auth_db)
+
+
+async def test_membership_revoke_refuses_non_manual(
+    auth_db, content_dir: Path
+):
+    from stash_mcp.cli.commands import CliError
+
+    await cmd_tenant_create(
+        _parse(["tenant", "create", "--slug", "acme", "--name", "A"]), auth_db
+    )
+    async with auth_db() as session:
+        user = User(
+            oidc_sub="alice", email="alice@example.com", display_name="A"
+        )
+        session.add(user)
+        await session.flush()
+        tenant = (
+            await session.execute(
+                select(Tenant).where(Tenant.slug == "acme")
+            )
+        ).scalar_one()
+        m = Membership(
+            user_id=user.id,
+            tenant_id=tenant.id,
+            role="admin",
+            source="oidc_group",
+        )
+        session.add(m)
+        await session.commit()
+        await session.refresh(m)
+        target_id = str(m.id)
+
+    ns = _parse(["membership", "revoke", target_id])
+    with pytest.raises(CliError):
+        await cmd_membership_revoke(ns, auth_db)

--- a/tests/routing/test_per_store_mcp.py
+++ b/tests/routing/test_per_store_mcp.py
@@ -3,17 +3,49 @@ store and confirm isolation."""
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from stash_mcp.auth.context import (
+    reset_current_principal,
+    set_current_principal,
+)
+from stash_mcp.auth.principal import Principal
 from stash_mcp.db.models import Store, Tenant
 from stash_mcp.git_backend import GitBackend
 from stash_mcp.mcp_server import USE_CURRENT_STORE, create_mcp_server
 from stash_mcp.routing.context import reset_current_store, set_current_store
-from stash_mcp.stores.registry import StoreRegistry
+from stash_mcp.stores.registry import LoadedStore, StoreRegistry
+
+
+def _admin_principal(tenant_id: UUID) -> Principal:
+    return Principal(
+        user_id=uuid4(),
+        oidc_sub="test-sub",
+        email="t@example.com",
+        display_name="Test",
+        auth_method="session",
+        tenant_roles={tenant_id: "admin"},
+    )
+
+
+@contextmanager
+def _scoped_store(store: LoadedStore):
+    """Set both the principal and store contextvars for the duration of a
+    direct tool call. Per-tool scope enforcement (added in spec 05) reads
+    both."""
+    p_token = set_current_principal(_admin_principal(store.tenant_id))
+    s_token = set_current_store(store)
+    try:
+        yield
+    finally:
+        reset_current_store(s_token)
+        reset_current_principal(p_token)
 
 
 @pytest.fixture
@@ -75,41 +107,26 @@ async def test_create_and_read_via_current_store(
     list_tool = await mcp.get_tool("list_content")
 
     # Write into store A
-    token = set_current_store(store_a)
-    try:
+    with _scoped_store(store_a):
         await create.run({"path": "a-only.md", "content": "from A"})
-    finally:
-        reset_current_store(token)
 
     # Read back from store A
-    token = set_current_store(store_a)
-    try:
+    with _scoped_store(store_a):
         result = await read.run({"path": "a-only.md"})
-    finally:
-        reset_current_store(token)
     assert "from A" in str(result.content)
 
     # Same path does not exist in store B
-    token = set_current_store(store_b)
-    try:
+    with _scoped_store(store_b):
         with pytest.raises(Exception):
             await read.run({"path": "a-only.md"})
-    finally:
-        reset_current_store(token)
 
     # list_content reflects each store's contents
-    token = set_current_store(store_a)
-    try:
+    with _scoped_store(store_a):
         a_listing = await list_tool.run({"path": "", "recursive": True})
-    finally:
-        reset_current_store(token)
     assert "a-only.md" in str(a_listing.content)
 
-    token = set_current_store(store_b)
-    try:
+    with _scoped_store(store_b):
         b_listing = await list_tool.run({"path": "", "recursive": True})
-    finally:
-        reset_current_store(token)
     assert "a-only.md" not in str(b_listing.content)
 
 
@@ -120,8 +137,14 @@ async def test_tool_call_without_store_raises(
     without setting the contextvar is a programmer error."""
     mcp = create_mcp_server(USE_CURRENT_STORE)
     list_tool = await mcp.get_tool("list_content")
-    with pytest.raises(RuntimeError, match="no store in scope"):
-        await list_tool.run({"path": "", "recursive": False})
+    # Set a principal so the spec-05 scope check passes; the missing-store
+    # check is what we're asserting on.
+    p_token = set_current_principal(_admin_principal(uuid4()))
+    try:
+        with pytest.raises(Exception, match="no store"):
+            await list_tool.run({"path": "", "recursive": False})
+    finally:
+        reset_current_principal(p_token)
 
 
 async def test_git_tools_registered_in_auth_mode(
@@ -151,12 +174,9 @@ async def test_git_tools_raise_when_store_has_no_git(
     mcp = create_mcp_server(USE_CURRENT_STORE)
     log_tool = await mcp.get_tool("log_content")
 
-    token = set_current_store(store)
-    try:
+    with _scoped_store(store):
         with pytest.raises(Exception, match="Git tracking is not enabled"):
             await log_tool.run({"path": "anything", "max_count": 1})
-    finally:
-        reset_current_store(token)
 
 
 async def test_transaction_tools_raise_when_store_has_no_git(
@@ -176,12 +196,9 @@ async def test_transaction_tools_raise_when_store_has_no_git(
     mcp = create_mcp_server(USE_CURRENT_STORE)
     start = await mcp.get_tool("start_content_transaction")
 
-    token = set_current_store(store)
-    try:
+    with _scoped_store(store):
         with pytest.raises(Exception, match="Transactions are not available"):
             await start.run({})
-    finally:
-        reset_current_store(token)
 
 
 async def test_git_tool_uses_per_store_backend(
@@ -216,10 +233,7 @@ async def test_git_tool_uses_per_store_backend(
     mcp = create_mcp_server(USE_CURRENT_STORE)
     log_tool = await mcp.get_tool("log_content")
 
-    token = set_current_store(store_a)
-    try:
+    with _scoped_store(store_a):
         result = await log_tool.run({"path": "file.md", "max_count": 5})
-    finally:
-        reset_current_store(token)
     text = str(result.content)
     assert "init" in text

--- a/tests/test_tool_scopes.py
+++ b/tests/test_tool_scopes.py
@@ -1,0 +1,235 @@
+"""Per-tool scope enforcement (spec 05).
+
+Direct invocation of MCP tool functions with principals of varying
+auth_method/scope, asserting that the wrapper raises ``AuthError`` for
+insufficient scope and lets the call through otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from stash_mcp.auth.context import (
+    reset_current_principal,
+    set_current_principal,
+)
+from stash_mcp.auth.principal import Principal
+from stash_mcp.config import Config
+from stash_mcp.db import engine as engine_mod
+from stash_mcp.db import session as session_mod
+from stash_mcp.db.models import Base, Store, Tenant
+from stash_mcp.mcp_server import USE_CURRENT_STORE, create_mcp_server
+from stash_mcp.routing.context import reset_current_store, set_current_store
+from stash_mcp.stores import registry as registry_mod
+from stash_mcp.stores.registry import StoreRegistry
+
+
+def _enable_sqlite_fks(engine: AsyncEngine) -> None:
+    @event.listens_for(engine.sync_engine, "connect")
+    def _fk_pragma(dbapi_connection, _record):  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+@pytest.fixture
+async def auth_db(monkeypatch: pytest.MonkeyPatch):
+    test_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    _enable_sqlite_fks(test_engine)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = async_sessionmaker(
+        test_engine, expire_on_commit=False, class_=AsyncSession
+    )
+    monkeypatch.setattr(engine_mod, "_engine", test_engine, raising=False)
+    monkeypatch.setattr(session_mod, "_sessionmaker", sm, raising=False)
+    monkeypatch.setattr(registry_mod, "_registry", None, raising=False)
+    monkeypatch.setattr(Config, "AUTH_ENABLED", True, raising=False)
+    monkeypatch.setattr(Config, "READ_ONLY", False, raising=False)
+    try:
+        yield sm
+    finally:
+        await test_engine.dispose()
+
+
+@pytest.fixture
+def content_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    monkeypatch.setattr(Config, "CONTENT_DIR", root, raising=False)
+    return root
+
+
+@pytest.fixture
+def mock_context():
+    from fastmcp.server.context import Context, _current_context
+
+    ctx = MagicMock(spec=Context)
+    ctx.session = AsyncMock()
+    ctx.send_resource_list_changed = AsyncMock()
+    token = _current_context.set(ctx)
+    yield ctx
+    _current_context.reset(token)
+
+
+async def _make_store(sm: async_sessionmaker, content_dir: Path):
+    async with sm() as session:
+        tenant = Tenant(slug="acme", display_name="Acme")
+        session.add(tenant)
+        await session.flush()
+        store = Store(
+            tenant_id=tenant.id,
+            slug="docs",
+            display_name="Docs",
+            git_branch="main",
+        )
+        session.add(store)
+        await session.commit()
+        await session.refresh(tenant)
+        await session.refresh(store)
+    (content_dir / str(tenant.id) / "docs").mkdir(parents=True)
+    registry = StoreRegistry()
+    loaded = await registry.get("acme", "docs")
+    return tenant, loaded
+
+
+def _principal(
+    *,
+    tenant_id: UUID,
+    role: str | None,
+    auth_method: str = "session",
+    api_scopes: str | None = None,
+) -> Principal:
+    tenant_roles = {tenant_id: role} if role is not None else {}
+    claims = {"scopes": api_scopes} if api_scopes is not None else {}
+    return Principal(
+        user_id=uuid4(),
+        oidc_sub="t",
+        email="t@x",
+        display_name="T",
+        auth_method=auth_method,  # type: ignore[arg-type]
+        tenant_roles=tenant_roles,  # type: ignore[arg-type]
+        claims=claims,
+    )
+
+
+async def _call(mcp, name: str, args: dict):
+    tool = await mcp.get_tool(name)
+    return await tool.run(args)
+
+
+async def test_member_can_read_and_write(
+    auth_db, content_dir, mock_context
+):
+    tenant, store = await _make_store(auth_db, content_dir)
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    p = _principal(tenant_id=tenant.id, role="member")
+    p_tok = set_current_principal(p)
+    s_tok = set_current_store(store)
+    try:
+        await _call(mcp, "create_content", {"path": "f.md", "content": "x"})
+        result = await _call(mcp, "read_content", {"path": "f.md"})
+        assert "x" in str(result.content)
+    finally:
+        reset_current_store(s_tok)
+        reset_current_principal(p_tok)
+
+
+async def test_no_membership_denies_read(
+    auth_db, content_dir, mock_context
+):
+    tenant, store = await _make_store(auth_db, content_dir)
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    p = _principal(tenant_id=tenant.id, role=None)
+    p_tok = set_current_principal(p)
+    s_tok = set_current_store(store)
+    try:
+        with pytest.raises(Exception, match="read"):
+            await _call(mcp, "list_content", {"path": "", "recursive": False})
+    finally:
+        reset_current_store(s_tok)
+        reset_current_principal(p_tok)
+
+
+async def test_api_token_read_only_blocked_from_write(
+    auth_db, content_dir, mock_context
+):
+    tenant, store = await _make_store(auth_db, content_dir)
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    p = _principal(
+        tenant_id=tenant.id,
+        role="member",  # role would otherwise grant write
+        auth_method="api_token",
+        api_scopes="read",  # but the token row scopes win
+    )
+    p_tok = set_current_principal(p)
+    s_tok = set_current_store(store)
+    try:
+        with pytest.raises(Exception, match="write"):
+            await _call(
+                mcp,
+                "create_content",
+                {"path": "x.md", "content": "x"},
+            )
+        # Read still works.
+        await _call(mcp, "list_content", {"path": "", "recursive": False})
+    finally:
+        reset_current_store(s_tok)
+        reset_current_principal(p_tok)
+
+
+async def test_api_token_with_write_scope_can_write(
+    auth_db, content_dir, mock_context
+):
+    tenant, store = await _make_store(auth_db, content_dir)
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    p = _principal(
+        tenant_id=tenant.id,
+        role=None,  # api_token ignores role entirely
+        auth_method="api_token",
+        api_scopes="read,write",
+    )
+    p_tok = set_current_principal(p)
+    s_tok = set_current_store(store)
+    try:
+        await _call(
+            mcp,
+            "create_content",
+            {"path": "x.md", "content": "x"},
+        )
+    finally:
+        reset_current_store(s_tok)
+        reset_current_principal(p_tok)
+
+
+async def test_auth_disabled_skips_scope_check(
+    auth_db, content_dir, mock_context, monkeypatch
+):
+    # Even with no principal, AUTH_ENABLED=False means the wrapper skips
+    # scope enforcement entirely (no behaviour change).
+    tenant, store = await _make_store(auth_db, content_dir)
+    monkeypatch.setattr(Config, "AUTH_ENABLED", False, raising=False)
+    mcp = create_mcp_server(USE_CURRENT_STORE)
+    s_tok = set_current_store(store)
+    try:
+        # Should not raise — even with no principal set.
+        await _call(mcp, "list_content", {"path": "", "recursive": False})
+    finally:
+        reset_current_store(s_tok)


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive admin interface for Stash-MCP, including HTTP endpoints for managing tenants, stores, users, and memberships, plus a CLI tool for provisioning. All admin operations are gated by role-based access control and include audit logging.

## Key Changes

### Admin HTTP API (`/admin/*`)
- **Tenant management**: Create, list, get, update (rename), and delete tenants
- **Store management**: Create, list, get, update, and delete stores within tenants with on-disk Git repository provisioning
- **User management**: List users and view their details
- **Membership management**: Grant/revoke tenant memberships with role assignment (admin/member)
- **Access control**: All endpoints require `admin` role on the default tenant via `require_admin` dependency
- **Audit logging**: All state-changing operations write audit events in the same transaction as the change

### Authentication Routes (`/auth/*`)
- **OIDC login/callback**: Implements authorization code flow with session cookie issuance
- **API token management**: Cookie-authenticated users can mint and revoke personal API tokens with configurable scopes and expiration
- **User/membership sync**: Shared `upsert_user_and_memberships` helper for materializing users from OIDC claims and syncing group-derived memberships

### CLI Tooling (`stash-mcp-cli`)
- Subcommands for tenant and store provisioning: `tenant create/list`, `store create/list`
- User and membership management: `user list`, `membership grant/revoke`
- Async database operations with proper error handling
- Composable plain-text output for shell integration

### Error Handling
- RFC 7807 Problem Details responses for all new endpoints
- Typed exception hierarchy (`StashError` subclasses) with standardized HTTP status codes
- Proper HTTP semantics: 201 for creation, 204 for deletion, 409 for conflicts, 412 for conditional failures

### Supporting Infrastructure
- **Principal scopes**: Role-based scope derivation for OIDC/session principals; explicit scopes for API tokens
- **Session middleware**: Added to auth-enabled app for cookie-based authentication
- **UI integration**: Display logged-in user and sign-out link in toolbar when AUTH_ENABLED
- **Test fixtures**: Comprehensive test infrastructure for admin/auth routes with in-memory SQLite and principal mocking

## Notable Implementation Details

- Audit events are written in the same DB transaction as state changes to prevent drift
- Store provisioning creates on-disk Git repositories via the store registry
- Tenant deletion requires all stores to be deleted first (referential integrity)
- Store deletion requires explicit confirmation flag to prevent accidents
- Admin role is currently global (on default tenant only); cross-tenant admins deferred to future spec
- API token callers and bearer-JWT callers are explicitly denied from minting new tokens (only session cookies allowed)
- OIDC user materialization is factored into shared helper used by both bearer-JWT and callback paths

https://claude.ai/code/session_017Ld2ysmfpdE1HgkjVvT1U4