### PR TITLE
Fix race conditions in file selection and store switching

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,11 +119,11 @@ Once the server is running, use the admin CLI to provision your first
 tenant and store:
 
 ```bash
-uv run stash-mcp tenant create --slug acme --display-name "Acme Inc"
-uv run stash-mcp store create --tenant acme --slug docs --display-name "Docs"
+uv run stash-mcp-cli tenant create --slug acme --name "Acme Inc"
+uv run stash-mcp-cli store create --tenant acme --slug docs --display-name "Docs"
 # Or, clone an existing repo into a store:
-uv run stash-mcp store create --tenant acme --slug docs \
-  --git-remote https://github.com/acme/docs.git
+uv run stash-mcp-cli store create --tenant acme --slug docs \
+  --remote https://github.com/acme/docs.git
 ```
 
 Stores live at `STASH_CONTENT_ROOT/<tenant_id>/<store_slug>/`. The

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,8 +70,17 @@ listing what's missing. See `Config.validate_auth_config()` in
 
 ### Postgres setup
 
-For production use Postgres. Stash uses `asyncpg`; install it as part of
-the deployment (it's pulled in by the main package).
+For production use Postgres. Stash talks to it via `asyncpg`, which is
+**not** a base dependency — pull it in via the `postgres` extra:
+
+```bash
+uv sync --extra postgres
+# or, with pip:
+pip install 'stash-mcp[postgres]'
+```
+
+Then create the database, point `STASH_DATABASE_URL` at it, and run the
+migrations:
 
 ```bash
 createdb stash

--- a/stash_mcp/main.py
+++ b/stash_mcp/main.py
@@ -495,22 +495,17 @@ def create_app():
     # Mount FastMCP server onto FastAPI for streamable HTTP transport
     app.mount("/mcp", mcp_http_app)
 
-    # Mount UI: when the React SPA dist exists, serve it at /ui and the legacy
-    # HTML UI at /ui/classic.  Without a dist, the legacy UI serves at /ui.
-    # The legacy router must be registered before the SPA mount so its specific
-    # routes take priority over the SPA catch-all.
-    has_frontend = FRONTEND_DIR.is_dir()
-    legacy_prefix = "/ui/classic" if has_frontend else "/ui"
+    # Legacy mode always serves the server-rendered HTML UI at /ui. The
+    # React SPA depends on /auth/* (which the legacy app doesn't mount), so
+    # serving it here would break the documented `/ui` flow — see
+    # docs/deployment.md.
     ui_router = create_ui_router(
         filesystem,
         search_engine=search_engine,
         read_only=Config.READ_ONLY,
-        prefix=legacy_prefix,
+        prefix="/ui",
     )
     app.include_router(ui_router)
-
-    if has_frontend:
-        mount_frontend(app)
 
     # Normalize /mcp → /mcp/ so the mounted sub-app handles requests to
     # both paths without a 307 redirect.  Redirects can break MCP clients

--- a/stash_mcp/main.py
+++ b/stash_mcp/main.py
@@ -310,6 +310,19 @@ def _create_auth_enabled_app() -> FastAPI:
     static_dir = Path(__file__).parent / "static"
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
+    # Mount the React SPA at /ui. The auth middleware already redirects
+    # unauthenticated GETs under /ui to /auth/login, and the SPA bootstraps
+    # itself by calling /auth/me + /auth/stores once the session cookie is
+    # in place.
+    if FRONTEND_DIR.is_dir():
+        mount_frontend(app)
+    else:
+        logger.warning(
+            "AUTH_ENABLED=true but %s does not exist — /ui will 404. "
+            "Build the SPA (npm run build in stash_ui/) or use the Docker image.",
+            FRONTEND_DIR,
+        )
+
     # Mount MCP under /mcp — the resolver rewrites /mcp/<tenant>/<store>/...
     # to /mcp/... before this subapp sees the request.
     app.mount("/mcp", mcp_http_app)

--- a/stash_ui/src/api/fetch.ts
+++ b/stash_ui/src/api/fetch.ts
@@ -72,6 +72,26 @@ export async function stashFetch(
       }
       throw new ProblemError(problem);
     }
+    // Legacy `{ "detail": "..." }` shape and arbitrary JSON. Read the body
+    // best-effort so the caller surfaces something more useful than
+    // `Failed to ...: ${statusText}`.
+    let message = res.statusText || `HTTP ${res.status}`;
+    if (contentType.includes('application/json')) {
+      try {
+        const body = (await res.json()) as unknown;
+        if (
+          body &&
+          typeof body === 'object' &&
+          'detail' in body &&
+          typeof (body as { detail: unknown }).detail === 'string'
+        ) {
+          message = (body as { detail: string }).detail;
+        }
+      } catch {
+        // Fall through to statusText.
+      }
+    }
+    throw new HttpError(res.status, message);
   }
 
   return res;

--- a/stash_ui/src/app/StoreContext.tsx
+++ b/stash_ui/src/app/StoreContext.tsx
@@ -2,12 +2,20 @@ import React, { createContext, useContext, useEffect, useMemo, useState } from '
 import { useNavigate, useParams } from 'react-router';
 import { getMyStores, StoreSummary } from '../api/auth';
 import { ApiClient, createApiClient } from '../api/client';
+import { HttpError } from '../api/fetch';
 
 interface StoreContextValue {
   stores: StoreSummary[];
   current: StoreSummary | null;
   loading: boolean;
+  // Populated when /auth/stores returned a non-404 failure. Distinct from
+  // `stores.length === 0` (which means "authed but no memberships") and
+  // from `authDisabled` (which means "this backend has no /auth/* router").
   error: string | null;
+  // `/auth/stores` returned 404, i.e. the backend was built without auth.
+  // The SPA is only supported on auth-enabled deployments — render a
+  // clear message instead of falling into the /no-stores flow.
+  authDisabled: boolean;
   setCurrent: (tenantSlug: string, storeSlug: string) => void;
   client: ApiClient | null;
 }
@@ -19,6 +27,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
   const [current, setCurrentState] = useState<StoreSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [authDisabled, setAuthDisabled] = useState(false);
   const navigate = useNavigate();
   const params = useParams();
 
@@ -40,7 +49,11 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
+        if (err instanceof HttpError && err.status === 404) {
+          setAuthDisabled(true);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
         setLoading(false);
       });
     return () => {
@@ -54,12 +67,22 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
   // Keep `current` in sync with the URL when the user navigates via the
   // store picker or browser nav. The picker calls `setCurrent` which in
   // turn `navigate()`s, then this effect picks up the new params.
+  //
+  // If the URL points at a store the user doesn't have — directly typed,
+  // bookmarked, or revoked since their last visit — null out `current`
+  // so consumers can render their own redirect/empty state instead of
+  // continuing to operate on the previously-selected store.
   useEffect(() => {
     if (stores.length === 0) return;
+    if (!params.tenant || !params.store) return;
     const match = stores.find(
       (s) => s.tenant_slug === params.tenant && s.slug === params.store
     );
-    if (match && match !== current) setCurrentState(match);
+    if (match) {
+      if (match !== current) setCurrentState(match);
+    } else if (current !== null) {
+      setCurrentState(null);
+    }
   }, [params.tenant, params.store, stores, current]);
 
   function setCurrent(tenantSlug: string, storeSlug: string) {
@@ -79,7 +102,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <StoreCtx.Provider
-      value={{ stores, current, loading, error, setCurrent, client }}
+      value={{ stores, current, loading, error, authDisabled, setCurrent, client }}
     >
       {children}
     </StoreCtx.Provider>

--- a/stash_ui/src/app/pages/DocumentsPage.tsx
+++ b/stash_ui/src/app/pages/DocumentsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Navigate } from 'react-router';
 import { FileNode, apiTreeToFileNodes } from '../types';
 import { ConcurrentEditError } from '../../api/fetch';
@@ -20,7 +20,22 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { GitBranchInfo } from '../mockData/gitChanges';
 
 export function DocumentsPage() {
-  const { stores, current, loading: storeLoading, client } = useStore();
+  const {
+    stores,
+    current,
+    loading: storeLoading,
+    error: storeError,
+    authDisabled,
+    client,
+  } = useStore();
+  // The latest client. Async fetches capture this at call time so they
+  // can detect that they're stale (the user switched stores while the
+  // request was in flight) and drop their result instead of stomping the
+  // newly-loaded store's state.
+  const clientRef = useRef(client);
+  useEffect(() => {
+    clientRef.current = client;
+  });
   const [fileTree, setFileTree] = useState<FileNode[]>([]);
   const [selectedFile, setSelectedFile] = useState<FileNode | null>(null);
   const [selectedEtag, setSelectedEtag] = useState<string | null>(null);
@@ -40,17 +55,22 @@ export function DocumentsPage() {
   const [gitInfo, setGitInfo] = useState<GitBranchInfo | null>(null);
 
   // Fetch the file tree from the API. Bound to the currently-selected
-  // store via the API client returned from `useStore`.
+  // store via the API client returned from `useStore`. Captures the
+  // active client at call time and drops the result if the user
+  // switched stores while the request was in flight.
   const refreshTree = useCallback(async () => {
     if (!client) return;
+    const reqClient = client;
     try {
-      const tree = await client.getTree();
+      const tree = await reqClient.getTree();
+      if (clientRef.current !== reqClient) return;
       setFileTree(apiTreeToFileNodes(tree));
     } catch (err) {
+      if (clientRef.current !== reqClient) return;
       console.error('Failed to load file tree:', err);
       toast.error('Failed to load file tree');
     } finally {
-      setIsLoading(false);
+      if (clientRef.current === reqClient) setIsLoading(false);
     }
   }, [client]);
 
@@ -59,11 +79,13 @@ export function DocumentsPage() {
   // hold a stale ETag.
   useEffect(() => {
     if (!client) return;
+    const reqClient = client;
     setIsLoading(true);
     setSelectedFile(null);
     setSelectedEtag(null);
     refreshTree();
-    client.getGitOverview().then((data) => {
+    reqClient.getGitOverview().then((data) => {
+      if (clientRef.current !== reqClient) return;
       if (data) setGitInfo(data as GitBranchInfo);
       else setGitInfo(null);
     });
@@ -81,47 +103,69 @@ export function DocumentsPage() {
     }
   }, [selectedFile]);
 
+  // Identifies the latest file-load request. Async fetches compare this
+  // against their own request id when they resolve so a slow load doesn't
+  // overwrite a newer selection's content.
+  const latestSelectionRef = useRef(0);
+
   // Load file content from the API when a file is selected
   const handleSelectFile = useCallback(async (file: FileNode) => {
     if (file.type === 'folder') {
+      latestSelectionRef.current += 1;
       setSelectedFile(file);
       setSelectedEtag(null);
       return;
     }
 
-    // If content is already loaded, just select it. Skip the cached
-    // shortcut after a save/move/etc that bumped the ETag — we always
-    // refetch when no ETag is in state for the file.
-    if (file.content !== undefined && selectedEtag !== null) {
+    // Cache hit: the FileNode carries its own content + ETag from a
+    // prior load. Use both — using the globally-tracked `selectedEtag`
+    // here would risk sending the previously-loaded file's ETag on the
+    // next save (false 412).
+    if (file.content !== undefined && file.etag) {
+      latestSelectionRef.current += 1;
       setSelectedFile(file);
+      setSelectedEtag(file.etag);
       return;
     }
 
     if (!client) return;
+    const reqClient = client;
+    const reqId = ++latestSelectionRef.current;
     setIsContentLoading(true);
     setSelectedFile(file);
+    setSelectedEtag(null);
 
     try {
-      const { content: data, etag } = await client.getContent(file.path);
+      const { content: data, etag } = await reqClient.getContent(file.path);
+      // Drop the result if the user switched stores or files while the
+      // request was in flight.
+      if (clientRef.current !== reqClient || latestSelectionRef.current !== reqId) {
+        return;
+      }
       const enrichedFile: FileNode = {
         ...file,
         content: data.content ?? '',
         size: data.content ? new TextEncoder().encode(data.content).length : 0,
         lastModified: data.updated_at ?? undefined,
         mimeType: data.mime_type ?? undefined,
+        etag: etag ?? undefined,
       };
       setSelectedFile(enrichedFile);
       setSelectedEtag(etag);
-
-      // Also update the file in the tree so re-selecting doesn't re-fetch
+      // Also update the file in the tree so re-selecting doesn't re-fetch.
       setFileTree((prev) => updateFileInTree(prev, file.id, enrichedFile));
     } catch (err) {
+      if (clientRef.current !== reqClient || latestSelectionRef.current !== reqId) {
+        return;
+      }
       console.error('Failed to load file content:', err);
       toast.error('Failed to load file content');
     } finally {
-      setIsContentLoading(false);
+      if (clientRef.current === reqClient && latestSelectionRef.current === reqId) {
+        setIsContentLoading(false);
+      }
     }
-  }, [client, selectedEtag]);
+  }, [client]);
 
   const updateFileInTree = (
     nodes: FileNode[],
@@ -154,6 +198,7 @@ export function DocumentsPage() {
         content,
         size: new TextEncoder().encode(content).length,
         lastModified: new Date().toISOString(),
+        etag: etag ?? undefined,
       };
       setSelectedFile(updatedFile);
       setSelectedEtag(etag);
@@ -178,6 +223,7 @@ export function DocumentsPage() {
               : 0,
             lastModified: data.updated_at ?? undefined,
             mimeType: data.mime_type ?? undefined,
+            etag: etag ?? undefined,
           };
           setSelectedFile(reloaded);
           setSelectedEtag(etag);
@@ -256,10 +302,12 @@ export function DocumentsPage() {
   const handleCreateDocument = async (path: string, content: string, _template: string) => {
     if (!client) return;
     try {
-      await client.createContent(path, content);
+      const { etag } = await client.createContent(path, content);
       await refreshTree();
 
-      // Select the newly created file
+      // Select the newly created file. Capturing the create ETag here is
+      // load-bearing — without it the next save would send whatever ETag
+      // happened to be in `selectedEtag` from the previous selection.
       const newFile: FileNode = {
         id: path,
         name: path.split('/').pop() || 'untitled',
@@ -269,8 +317,11 @@ export function DocumentsPage() {
         content,
         size: new TextEncoder().encode(content).length,
         lastModified: new Date().toISOString(),
+        etag: etag ?? undefined,
       };
+      latestSelectionRef.current += 1;
       setSelectedFile(newFile);
+      setSelectedEtag(etag);
       setIsNewDocModalOpen(false);
       toast.success('Document created');
     } catch (err) {
@@ -322,8 +373,16 @@ export function DocumentsPage() {
 
   // The URL pointed at a tenant/store the user can't see (or that
   // doesn't exist for them). Bounce: no stores → /no-stores; otherwise
-  // land them on the first one they do have.
+  // land them on the first one they do have. Auth-disabled and outright
+  // errors render their own state at the root route, but we surface them
+  // here too in case the user deep-linked.
   if (!current) {
+    if (authDisabled) {
+      return <Navigate to="/" replace />;
+    }
+    if (storeError) {
+      return <Navigate to="/" replace />;
+    }
     if (stores.length === 0) return <Navigate to="/no-stores" replace />;
     const first = stores[0];
     return (

--- a/stash_ui/src/app/pages/DocumentsPage.tsx
+++ b/stash_ui/src/app/pages/DocumentsPage.tsx
@@ -114,6 +114,10 @@ export function DocumentsPage() {
       latestSelectionRef.current += 1;
       setSelectedFile(file);
       setSelectedEtag(null);
+      // Owning the loading flag: bumping the ref invalidates any
+      // in-flight uncached load, whose `finally` will now no-op. Clear
+      // here so the spinner doesn't get stuck on top of the folder view.
+      setIsContentLoading(false);
       return;
     }
 
@@ -125,6 +129,9 @@ export function DocumentsPage() {
       latestSelectionRef.current += 1;
       setSelectedFile(file);
       setSelectedEtag(file.etag);
+      // Same reason as the folder branch — clear in case an earlier
+      // uncached load set the spinner and is now invalidated.
+      setIsContentLoading(false);
       return;
     }
 

--- a/stash_ui/src/app/routes.tsx
+++ b/stash_ui/src/app/routes.tsx
@@ -17,8 +17,32 @@ function StoreShell() {
 }
 
 function RootRedirect() {
-  const { stores, loading } = useStore();
+  const { stores, loading, error, authDisabled } = useStore();
   if (loading) return null;
+  if (authDisabled) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center p-6">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-xl">Auth not enabled</h1>
+          <p className="text-sm opacity-70">
+            This Stash deployment is running with{' '}
+            <code>STASH_AUTH_ENABLED=false</code>. The React UI requires
+            an auth-enabled backend. Use the server-rendered UI instead.
+          </p>
+        </div>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center p-6">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-xl">Couldn't load stores</h1>
+          <p className="text-sm opacity-70">{error}</p>
+        </div>
+      </div>
+    );
+  }
   if (stores.length === 0) return <Navigate to="/no-stores" replace />;
   const first = stores[0];
   return <Navigate to={`/${first.tenant_slug}/${first.slug}`} replace />;

--- a/stash_ui/src/app/types.ts
+++ b/stash_ui/src/app/types.ts
@@ -9,6 +9,10 @@ export interface FileNode {
   size?: number;
   lastModified?: string;
   mimeType?: string;
+  // Last-known ETag for the file's content. Stored alongside the cached
+  // content so re-selecting a file uses its own ETag, not whichever file
+  // was loaded most recently.
+  etag?: string;
 }
 
 export interface DocumentMetadata {

--- a/tests/auth/test_session_cookies.py
+++ b/tests/auth/test_session_cookies.py
@@ -25,9 +25,13 @@ def test_roundtrip_returns_same_payload():
 
 def test_tampered_cookie_returns_none():
     cookie = session_mod.issue_session("u-1", "oidc-sub-1")
-    # Flip a character in the signed portion. Length stays the same so the
-    # decoder runs but the signature check fails.
-    tampered = cookie[:-1] + ("A" if cookie[-1] != "A" else "B")
+    # Replace the signature with one that definitely doesn't match. Flipping
+    # the last char of the cookie is not safe: itsdangerous URL-safe-
+    # base64-encodes a 20-byte HMAC into 27 chars, leaving 2 slack bits in
+    # the last char, so swapping (say) A↔B can decode to the same signature
+    # bytes and make this test flake.
+    payload_and_timestamp, sig = cookie.rsplit(".", 1)
+    tampered = payload_and_timestamp + "." + "X" * len(sig)
     assert session_mod.verify_session(tampered) is None
 
 


### PR DESCRIPTION
## Summary
This PR fixes critical race conditions in the DocumentsPage component that could cause stale data to overwrite fresh state when users rapidly switch files or stores. It also improves error handling for auth-disabled deployments and adds ETag tracking to prevent false 412 conflicts on saves.

## Key Changes

- **Store switching race condition**: Added `clientRef` to track the latest API client. Async requests now capture the client at call time and drop their results if the user switched stores while the request was in flight, preventing stale data from overwriting newly-loaded store state.

- **File selection race condition**: Introduced `latestSelectionRef` to track the most recent file selection request ID. Slow file loads can no longer overwrite newer selections, and the component properly handles rapid file switching.

- **ETag tracking**: Added `etag` field to `FileNode` to store the last-known ETag alongside cached content. This ensures re-selecting a file uses its own ETag rather than whatever file was loaded most recently, preventing false 412 conflicts on saves.

- **Auth-disabled handling**: Enhanced `StoreContext` to distinguish between auth-disabled deployments (404 from `/auth/stores`) and actual errors. Added `authDisabled` flag and proper error state propagation. The React SPA now renders clear error messages for auth-disabled backends instead of falling into the `/no-stores` flow.

- **Store URL validation**: Fixed `StoreContext` to null out `current` when the URL points to a store the user doesn't have access to (directly typed, bookmarked, or revoked), allowing consumers to render appropriate redirect/empty states.

- **Error message improvements**: Enhanced `stashFetch` to extract and surface meaningful error messages from JSON error responses (both RFC 7807 `ProblemError` and legacy `{ "detail": "..." }` formats).

- **Deployment documentation**: Clarified Postgres setup requirements, noting that `asyncpg` must be explicitly installed via the `postgres` extra. Updated CLI command examples to use `stash-mcp-cli` and corrected flag names.

- **Legacy mode routing**: Adjusted legacy UI mounting to always serve at `/ui` in legacy mode, since the React SPA depends on `/auth/*` endpoints that legacy deployments don't provide.

## Implementation Details

- Request staleness detection uses reference equality checks (`clientRef.current !== reqClient`) rather than version numbers, keeping the pattern simple and idiomatic.
- The `latestSelectionRef` counter increments on every selection attempt (including folder selections), ensuring even rapid folder/file toggling is handled correctly.
- ETag is now captured at multiple points: file load, save, move, and create operations, ensuring the selected file always has a current ETag.
- Error state is properly threaded through the context and rendered at both the root route and DocumentsPage, providing consistent UX for auth failures.

https://claude.ai/code/session_015oVyieviTi6TDqQf4CrzKo