### PR TITLE
fix: copy alembic files into image so migrations can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy project files
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md alembic.ini ./
 COPY stash_mcp ./stash_mcp
+COPY alembic ./alembic
 
 # Copy built frontend assets from stage 1
 COPY --from=frontend /build/dist ./stash_ui/dist

--- a/docker-compose.dev-auth.yml
+++ b/docker-compose.dev-auth.yml
@@ -79,7 +79,7 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - |
-        uv run stash-mcp-migrate upgrade head && \
+        uv run alembic upgrade head && \
         exec uv run stash-mcp
     restart: unless-stopped
 


### PR DESCRIPTION
The Dockerfile only copied stash_mcp/ and missed alembic.ini + alembic/, so `uv run alembic upgrade head` (or the stash-mcp-migrate script) had nothing to read. Add them, and switch the compose entrypoint to invoke the alembic CLI directly — alembic is always present as a top-level dep, so this avoids stale-image issues where the project-level stash-mcp-migrate console script isn't yet installed in a cached venv.

https://claude.ai/code/session_01VY6gJ8jeYuYRDcg82p83Po