### PR TITLE
Add user account settings modal with profile and appearance tabs

### DIFF
--- a/stash_ui/src/app/StoreContext.tsx
+++ b/stash_ui/src/app/StoreContext.tsx
@@ -1,12 +1,13 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { getMyStores, StoreSummary } from '../api/auth';
+import { getMe, getMyStores, Me, StoreSummary } from '../api/auth';
 import { ApiClient, createApiClient } from '../api/client';
 import { HttpError } from '../api/fetch';
 
 interface StoreContextValue {
   stores: StoreSummary[];
   current: StoreSummary | null;
+  me: Me | null;
   loading: boolean;
   // Populated when /auth/stores returned a non-404 failure. Distinct from
   // `stores.length === 0` (which means "authed but no memberships") and
@@ -25,6 +26,7 @@ const StoreCtx = createContext<StoreContextValue | null>(null);
 export function StoreProvider({ children }: { children: React.ReactNode }) {
   const [stores, setStores] = useState<StoreSummary[]>([]);
   const [current, setCurrentState] = useState<StoreSummary | null>(null);
+  const [me, setMe] = useState<Me | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [authDisabled, setAuthDisabled] = useState(false);
@@ -33,9 +35,13 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    getMyStores()
-      .then((data) => {
+    // Load identity and store memberships in parallel. Both are gated
+    // behind the same auth router on the backend; a 404 on either means
+    // the deployment is running without auth.
+    Promise.all([getMe(), getMyStores()])
+      .then(([meData, data]) => {
         if (cancelled) return;
+        setMe(meData);
         setStores(data);
         const tenantFromUrl = params.tenant;
         const storeFromUrl = params.store;
@@ -102,7 +108,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <StoreCtx.Provider
-      value={{ stores, current, loading, error, authDisabled, setCurrent, client }}
+      value={{ stores, current, me, loading, error, authDisabled, setCurrent, client }}
     >
       {children}
     </StoreCtx.Provider>

--- a/stash_ui/src/app/components/FileTree.tsx
+++ b/stash_ui/src/app/components/FileTree.tsx
@@ -11,9 +11,13 @@ interface FileTreeProps {
   onClearSelection?: () => void;
   onNewDocument: () => void;
   onOpenSettings?: () => void;
+  onOpenOrgSettings?: () => void;
   onMoveItem?: (item: FileNode) => void;
   onDeleteItem?: (item: FileNode) => void;
   gitInfo?: GitBranchInfo;
+  userName: string;
+  userEmail: string;
+  isTenantAdmin: boolean;
 }
 
 interface FileTreeItemProps {
@@ -116,7 +120,7 @@ function FileTreeItem({ node, level, selectedFile, onSelectFile, onMoveItem, onD
   );
 }
 
-export function FileTree({ tree, selectedFile, onSelectFile, onClearSelection, onNewDocument, onOpenSettings, onMoveItem, onDeleteItem, gitInfo }: FileTreeProps) {
+export function FileTree({ tree, selectedFile, onSelectFile, onClearSelection, onNewDocument, onOpenSettings, onOpenOrgSettings, onMoveItem, onDeleteItem, gitInfo, userName, userEmail, isTenantAdmin }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState('');
 
   const filterTree = (nodes: FileNode[], query: string): FileNode[] => {
@@ -259,9 +263,11 @@ export function FileTree({ tree, selectedFile, onSelectFile, onClearSelection, o
 
       {/* User Badge */}
       <UserBadge
-        name="Dylan Turner"
-        email="dylan@example.com"
+        name={userName}
+        email={userEmail}
+        showOrgSettings={isTenantAdmin}
         onOpenSettings={onOpenSettings}
+        onOpenOrgSettings={onOpenOrgSettings}
       />
     </div>
   );

--- a/stash_ui/src/app/components/OrganizationSettingsModal.tsx
+++ b/stash_ui/src/app/components/OrganizationSettingsModal.tsx
@@ -8,20 +8,18 @@ import {
   Lock,
   LockOpen,
   Edit2,
-  Palette,
 } from "lucide-react";
 import {
   CreateServerModal,
   ServerConfig,
 } from "./CreateServerModal";
-import { AppearanceSettings } from "./AppearanceSettings";
 
 interface OrganizationSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-type SettingsTab = "general" | "servers" | "appearance";
+type SettingsTab = "general" | "servers";
 
 export function OrganizationSettingsModal({
   isOpen,
@@ -42,11 +40,6 @@ export function OrganizationSettingsModal({
       id: "servers" as SettingsTab,
       label: "MCP Servers",
       icon: Server,
-    },
-    {
-      id: "appearance" as SettingsTab,
-      label: "Appearance",
-      icon: Palette,
     },
   ];
 
@@ -144,7 +137,6 @@ export function OrganizationSettingsModal({
           <div className="flex-1 overflow-y-auto p-6">
             {activeTab === "general" && <GeneralSettings />}
             {activeTab === "servers" && <ServerSettings />}
-            {activeTab === "appearance" && <AppearanceSettings />}
           </div>
         </div>
       </div>

--- a/stash_ui/src/app/components/UserBadge.tsx
+++ b/stash_ui/src/app/components/UserBadge.tsx
@@ -1,14 +1,26 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { User, Settings, LogOut, ChevronUp } from 'lucide-react';
+import { Settings, Building2, LogOut, ChevronUp } from 'lucide-react';
 
 interface UserBadgeProps {
   name: string;
   email: string;
   avatarUrl?: string;
+  // Show the "Organization Settings" menu entry. Reserved for tenant
+  // admins so non-admins don't see (or attempt to use) controls they
+  // can't apply.
+  showOrgSettings?: boolean;
   onOpenSettings?: () => void;
+  onOpenOrgSettings?: () => void;
 }
 
-export function UserBadge({ name, email, avatarUrl, onOpenSettings }: UserBadgeProps) {
+export function UserBadge({
+  name,
+  email,
+  avatarUrl,
+  showOrgSettings = false,
+  onOpenSettings,
+  onOpenOrgSettings,
+}: UserBadgeProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -31,11 +43,12 @@ export function UserBadge({ name, email, avatarUrl, onOpenSettings }: UserBadgeP
 
   const handleMenuAction = (action: string) => {
     setIsMenuOpen(false);
-    if (action === 'settings' && onOpenSettings) {
-      onOpenSettings();
-    } else {
-      // Mock actions - in real implementation, these would trigger actual auth flows
-      console.log(`User action: ${action}`);
+    if (action === 'settings') {
+      onOpenSettings?.();
+    } else if (action === 'org-settings') {
+      onOpenOrgSettings?.();
+    } else if (action === 'logout') {
+      window.location.href = '/auth/logout';
     }
   };
 
@@ -82,8 +95,27 @@ export function UserBadge({ name, email, avatarUrl, onOpenSettings }: UserBadgeP
             }}
           >
             <Settings className="w-4 h-4" />
-            <span>Settings</span>
+            <span>Account Settings</span>
           </button>
+          {showOrgSettings && (
+            <button
+              onClick={() => handleMenuAction('org-settings')}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-all duration-150"
+              style={{
+                backgroundColor: 'transparent',
+                color: 'var(--stash-text-primary)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--stash-bg-hover)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
+              }}
+            >
+              <Building2 className="w-4 h-4" />
+              <span>Organization Settings</span>
+            </button>
+          )}
           <div style={{ height: '1px', backgroundColor: 'var(--stash-border)' }} />
           <button
             onClick={() => handleMenuAction('logout')}

--- a/stash_ui/src/app/components/UserSettingsModal.tsx
+++ b/stash_ui/src/app/components/UserSettingsModal.tsx
@@ -1,0 +1,306 @@
+import React, { useState } from "react";
+import { X, User, Palette, KeyRound, Shield } from "lucide-react";
+import { Me, StoreSummary } from "../../api/auth";
+import { AppearanceSettings } from "./AppearanceSettings";
+
+interface UserSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  me: Me;
+  stores: StoreSummary[];
+}
+
+type SettingsTab = "profile" | "appearance" | "tokens";
+
+export function UserSettingsModal({
+  isOpen,
+  onClose,
+  me,
+  stores,
+}: UserSettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<SettingsTab>("profile");
+
+  if (!isOpen) return null;
+
+  const tabs = [
+    { id: "profile" as SettingsTab, label: "Profile", icon: User },
+    { id: "appearance" as SettingsTab, label: "Appearance", icon: Palette },
+    { id: "tokens" as SettingsTab, label: "API Tokens", icon: KeyRound },
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.6)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-4xl h-[80vh] flex flex-col rounded-lg shadow-2xl overflow-hidden"
+        style={{
+          backgroundColor: "var(--stash-bg-surface)",
+          border: "1px solid var(--stash-border)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-6 py-4 border-b"
+          style={{ borderColor: "var(--stash-border)" }}
+        >
+          <h2
+            className="text-lg font-semibold"
+            style={{ color: "var(--stash-text-bright)" }}
+          >
+            Account Settings
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded transition-all duration-150"
+            style={{ color: "var(--stash-text-secondary)" }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = "var(--stash-bg-hover)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = "transparent";
+            }}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex flex-1 overflow-hidden">
+          <div
+            className="w-56 border-r overflow-y-auto"
+            style={{
+              backgroundColor: "var(--stash-bg-base)",
+              borderColor: "var(--stash-border)",
+            }}
+          >
+            <nav className="p-2">
+              {tabs.map((tab) => {
+                const Icon = tab.icon;
+                const isActive = activeTab === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className="w-full flex items-center gap-3 px-4 py-2.5 rounded-md text-sm transition-all duration-150 mb-1"
+                    style={{
+                      backgroundColor: isActive
+                        ? "var(--stash-bg-surface)"
+                        : "transparent",
+                      color: isActive
+                        ? "var(--stash-accent)"
+                        : "var(--stash-text-primary)",
+                    }}
+                    onMouseEnter={(e) => {
+                      if (!isActive) {
+                        e.currentTarget.style.backgroundColor =
+                          "var(--stash-bg-hover)";
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isActive) {
+                        e.currentTarget.style.backgroundColor = "transparent";
+                      }
+                    }}
+                  >
+                    <Icon className="w-4 h-4" />
+                    <span>{tab.label}</span>
+                  </button>
+                );
+              })}
+            </nav>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-6">
+            {activeTab === "profile" && (
+              <ProfileSettings me={me} stores={stores} />
+            )}
+            {activeTab === "appearance" && <AppearanceSettings />}
+            {activeTab === "tokens" && <TokensRedirect />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProfileSettings({ me, stores }: { me: Me; stores: StoreSummary[] }) {
+  // Group memberships by tenant so the user can see their role per tenant
+  // in one place. The role on each `StoreSummary` row matches the
+  // tenant-level role in `me.tenant_roles`, so dedupe on tenant slug.
+  const tenantRows = Array.from(
+    new Map(
+      stores.map((s) => [
+        s.tenant_slug,
+        {
+          tenant_slug: s.tenant_slug,
+          tenant_display_name: s.tenant_display_name,
+          role: s.role,
+        },
+      ]),
+    ).values(),
+  );
+
+  return (
+    <div>
+      <h3
+        className="text-base font-semibold mb-4"
+        style={{ color: "var(--stash-text-bright)" }}
+      >
+        Profile
+      </h3>
+      <p
+        className="text-sm mb-6"
+        style={{ color: "var(--stash-text-secondary)" }}
+      >
+        Your account details, as provided by your identity provider.
+      </p>
+
+      <div className="space-y-4">
+        <ReadOnlyField label="Display name" value={me.display_name} />
+        <ReadOnlyField label="Email" value={me.email} />
+        <ReadOnlyField
+          label="Authentication method"
+          value={
+            me.auth_method === "oidc"
+              ? "Single sign-on (OIDC)"
+              : me.auth_method === "api_token"
+                ? "API token"
+                : "Browser session"
+          }
+        />
+      </div>
+
+      <div className="mt-8">
+        <h4
+          className="text-sm font-semibold mb-2 flex items-center gap-2"
+          style={{ color: "var(--stash-text-bright)" }}
+        >
+          <Shield className="w-4 h-4" />
+          Organization memberships
+        </h4>
+        <p
+          className="text-xs mb-3"
+          style={{ color: "var(--stash-text-secondary)" }}
+        >
+          Roles are managed by tenant admins. Contact an admin to request a
+          change.
+        </p>
+        {tenantRows.length === 0 ? (
+          <div
+            className="p-4 rounded-md text-sm"
+            style={{
+              backgroundColor: "var(--stash-bg-base)",
+              border: "1px dashed var(--stash-border)",
+              color: "var(--stash-text-secondary)",
+            }}
+          >
+            You aren't a member of any organizations yet.
+          </div>
+        ) : (
+          <div
+            className="rounded-md overflow-hidden"
+            style={{ border: "1px solid var(--stash-border)" }}
+          >
+            {tenantRows.map((row, idx) => (
+              <div
+                key={row.tenant_slug}
+                className="flex items-center justify-between px-4 py-2.5 text-sm"
+                style={{
+                  backgroundColor: "var(--stash-bg-base)",
+                  borderTop:
+                    idx === 0 ? "none" : "1px solid var(--stash-border)",
+                }}
+              >
+                <div>
+                  <div style={{ color: "var(--stash-text-bright)" }}>
+                    {row.tenant_display_name}
+                  </div>
+                  <div
+                    className="text-xs"
+                    style={{ color: "var(--stash-text-secondary)" }}
+                  >
+                    {row.tenant_slug}
+                  </div>
+                </div>
+                <span
+                  className="text-xs px-2 py-0.5 rounded uppercase tracking-wide"
+                  style={{
+                    backgroundColor: "var(--stash-bg-surface)",
+                    color:
+                      row.role === "admin"
+                        ? "var(--stash-accent)"
+                        : "var(--stash-text-secondary)",
+                    border: `1px solid ${
+                      row.role === "admin"
+                        ? "var(--stash-accent)"
+                        : "var(--stash-border)"
+                    }`,
+                  }}
+                >
+                  {row.role}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <label
+        className="block text-sm mb-2"
+        style={{ color: "var(--stash-text-primary)" }}
+      >
+        {label}
+      </label>
+      <input
+        type="text"
+        value={value}
+        readOnly
+        className="w-full px-3 py-2 rounded-md text-sm outline-none"
+        style={{
+          backgroundColor: "var(--stash-bg-base)",
+          color: "var(--stash-text-primary)",
+          border: "1px solid var(--stash-border)",
+        }}
+      />
+    </div>
+  );
+}
+
+function TokensRedirect() {
+  return (
+    <div>
+      <h3
+        className="text-base font-semibold mb-4"
+        style={{ color: "var(--stash-text-bright)" }}
+      >
+        API Tokens
+      </h3>
+      <p
+        className="text-sm mb-4"
+        style={{ color: "var(--stash-text-secondary)" }}
+      >
+        Manage personal API tokens to access Stash from scripts, agents, or
+        external services.
+      </p>
+      <a
+        href="/ui/account/tokens"
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm transition-all duration-150"
+        style={{
+          backgroundColor: "var(--stash-accent)",
+          color: "var(--stash-bg-base)",
+        }}
+      >
+        <KeyRound className="w-4 h-4" />
+        Open token manager
+      </a>
+    </div>
+  );
+}

--- a/stash_ui/src/app/pages/DocumentsPage.tsx
+++ b/stash_ui/src/app/pages/DocumentsPage.tsx
@@ -11,6 +11,7 @@ import { MetadataPanel } from '../components/MetadataPanel';
 import { OverviewContent } from '../components/OverviewContent';
 import { NewDocumentModal } from '../components/NewDocumentModal';
 import { OrganizationSettingsModal } from '../components/OrganizationSettingsModal';
+import { UserSettingsModal } from '../components/UserSettingsModal';
 import { Heading } from '../components/TableOfContents';
 import { Endpoint } from '../components/EndpointsList';
 import { Section } from '../components/SectionsList';
@@ -23,11 +24,13 @@ export function DocumentsPage() {
   const {
     stores,
     current,
+    me,
     loading: storeLoading,
     error: storeError,
     authDisabled,
     client,
   } = useStore();
+  const isTenantAdmin = current?.role === 'admin';
   // The latest client. Async fetches capture this at call time so they
   // can detect that they're stale (the user switched stores while the
   // request was in flight) and drop their result instead of stomping the
@@ -44,7 +47,8 @@ export function DocumentsPage() {
   const [isLeftPanelOpen, setIsLeftPanelOpen] = useState(true);
   const [isRightPanelOpen, setIsRightPanelOpen] = useState(true);
   const [isNewDocModalOpen, setIsNewDocModalOpen] = useState(false);
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const [isUserSettingsOpen, setIsUserSettingsOpen] = useState(false);
+  const [isOrgSettingsOpen, setIsOrgSettingsOpen] = useState(false);
   const [headings, setHeadings] = useState<Heading[]>([]);
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
   const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
@@ -539,10 +543,16 @@ export function DocumentsPage() {
                 onSelectFile={handleSelectFile}
                 onClearSelection={() => setSelectedFile(null)}
                 onNewDocument={() => setIsNewDocModalOpen(true)}
-                onOpenSettings={() => setIsSettingsModalOpen(true)}
+                onOpenSettings={() => setIsUserSettingsOpen(true)}
+                onOpenOrgSettings={
+                  isTenantAdmin ? () => setIsOrgSettingsOpen(true) : undefined
+                }
                 onMoveItem={handleMoveItem}
                 onDeleteItem={handleDeleteItemFromListing}
                 gitInfo={gitInfo ?? undefined}
+                userName={me?.display_name ?? me?.email ?? 'Signed in'}
+                userEmail={me?.email ?? ''}
+                isTenantAdmin={isTenantAdmin}
               />
             </Panel>
             <PanelResizeHandle
@@ -670,11 +680,25 @@ export function DocumentsPage() {
         onCreate={handleCreateDocument}
       />
 
-      {/* Organization Settings Modal */}
-      <OrganizationSettingsModal
-        isOpen={isSettingsModalOpen}
-        onClose={() => setIsSettingsModalOpen(false)}
-      />
+      {/* User (Account) Settings Modal */}
+      {me && (
+        <UserSettingsModal
+          isOpen={isUserSettingsOpen}
+          onClose={() => setIsUserSettingsOpen(false)}
+          me={me}
+          stores={stores}
+        />
+      )}
+
+      {/* Organization Settings Modal — admins only. The badge dropdown
+          gates the entry point, but guard here too in case the modal
+          state is forced open through some other path. */}
+      {isTenantAdmin && (
+        <OrganizationSettingsModal
+          isOpen={isOrgSettingsOpen}
+          onClose={() => setIsOrgSettingsOpen(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR introduces a new user account settings modal that allows users to view and manage their profile information, appearance preferences, and API tokens. The modal is accessible from the user badge dropdown menu and complements the existing organization settings modal.

## Key Changes

- **New UserSettingsModal component**: A comprehensive settings interface with three tabs:
  - Profile: Displays read-only account details (display name, email, auth method) and organization memberships with roles
  - Appearance: Delegates to existing AppearanceSettings component
  - API Tokens: Provides a link to the dedicated token manager page

- **Updated UserBadge component**: 
  - Renamed "Settings" to "Account Settings" for clarity
  - Added conditional "Organization Settings" menu entry (visible only to tenant admins)
  - Added `showOrgSettings` and `onOpenOrgSettings` props to control admin-only features
  - Implemented proper logout redirect to `/auth/logout`

- **Enhanced StoreContext**: 
  - Added `me` state to track current user identity information
  - Parallel loading of user identity (`getMe`) and store memberships (`getMyStores`)
  - Exports `Me` type for use throughout the application

- **Updated DocumentsPage**:
  - Separated user settings and organization settings into distinct modals
  - Added `isTenantAdmin` flag to gate organization settings access
  - Passes user information (name, email, admin status) to FileTree component
  - Guards organization settings modal behind admin role check

- **Updated FileTree component**:
  - Accepts user information props (userName, userEmail, isTenantAdmin)
  - Passes these to UserBadge for dynamic display and conditional menu items
  - Passes organization settings callback only when user is admin

- **Refactored OrganizationSettingsModal**:
  - Removed "Appearance" tab (moved to user account settings)
  - Now focuses solely on organization-level settings (general, servers)

## Implementation Details

- Organization memberships are deduplicated by tenant slug to show each tenant once with the user's role
- Appearance settings are now user-scoped rather than organization-scoped
- Admin-only features are gated at both the UI entry point (badge dropdown) and modal render level for defense in depth
- All styling uses CSS custom properties for theme consistency

https://claude.ai/code/session_01KMjZn4EtR5PX3B7prssz26