### PR TITLE
ui: restore Overview link, move store picker into sidebar, dedupe header buttons

### DIFF
--- a/stash_ui/src/app/components/FileTree.tsx
+++ b/stash_ui/src/app/components/FileTree.tsx
@@ -230,7 +230,7 @@ export function FileTree({ tree, selectedFile, onSelectFile, onClearSelection, o
           ) : (
             <LayoutDashboard
               className="w-4 h-4 flex-shrink-0"
-              style={{ color: 'var(--stash-accent)' }}
+              style={{ color: 'var(--stash-text-secondary)' }}
             />
           )}
           <span

--- a/stash_ui/src/app/components/FileTree.tsx
+++ b/stash_ui/src/app/components/FileTree.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { FileNode } from '../types';
-import { ChevronRight, ChevronDown, FileText, Folder, FolderOpen, Search, Plus, GitBranch } from 'lucide-react';
+import { ChevronRight, ChevronDown, FileText, Folder, FolderOpen, Search, Plus, GitBranch, LayoutDashboard } from 'lucide-react';
 import { UserBadge } from './UserBadge';
 import { GitBranchInfo } from '../mockData/gitChanges';
 
@@ -192,57 +192,64 @@ export function FileTree({ tree, selectedFile, onSelectFile, onClearSelection, o
         </div>
       </div>
 
-      {/* Branch/Activity Button */}
-      {gitInfo && (
-        <button
-          onClick={() => {
-            if (onClearSelection) {
-              onClearSelection();
-            }
-          }}
-          className="flex items-center justify-between px-3 py-2.5 border-b transition-colors duration-150"
-          style={{ 
-            borderColor: 'var(--stash-border)',
-            backgroundColor: !selectedFile ? 'var(--stash-bg-hover)' : 'transparent'
-          }}
-          onMouseEnter={(e) => {
-            if (selectedFile) {
-              e.currentTarget.style.backgroundColor = 'var(--stash-bg-hover)';
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (selectedFile) {
-              e.currentTarget.style.backgroundColor = 'transparent';
-            }
-          }}
-        >
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <ChevronRight 
-              className="w-4 h-4 flex-shrink-0" 
-              style={{ color: 'var(--stash-text-secondary)' }} 
+      {/* Overview Button */}
+      <button
+        onClick={() => {
+          if (onClearSelection) {
+            onClearSelection();
+          }
+        }}
+        className="flex items-center justify-between px-3 py-2.5 border-b transition-colors duration-150"
+        style={{
+          borderColor: 'var(--stash-border)',
+          backgroundColor: !selectedFile ? 'var(--stash-bg-hover)' : 'transparent'
+        }}
+        onMouseEnter={(e) => {
+          if (selectedFile) {
+            e.currentTarget.style.backgroundColor = 'var(--stash-bg-hover)';
+          }
+        }}
+        onMouseLeave={(e) => {
+          if (selectedFile) {
+            e.currentTarget.style.backgroundColor = 'transparent';
+          }
+        }}
+      >
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <ChevronRight
+            className="w-4 h-4 flex-shrink-0"
+            style={{ color: 'var(--stash-text-secondary)' }}
+          />
+          {gitInfo ? (
+            <GitBranch
+              className="w-4 h-4 flex-shrink-0"
+              style={{ color: 'var(--stash-accent)' }}
             />
-            <GitBranch 
-              className="w-4 h-4 flex-shrink-0" 
-              style={{ color: 'var(--stash-accent)' }} 
+          ) : (
+            <LayoutDashboard
+              className="w-4 h-4 flex-shrink-0"
+              style={{ color: 'var(--stash-accent)' }}
             />
-            <span 
-              className="text-sm truncate"
-              style={{ color: 'var(--stash-text-primary)' }}
-            >
-              Overview
-            </span>
-          </div>
-          <div 
+          )}
+          <span
+            className="text-sm truncate"
+            style={{ color: 'var(--stash-text-primary)' }}
+          >
+            Overview
+          </span>
+        </div>
+        {gitInfo && (
+          <div
             className="flex items-center justify-center w-5 h-5 text-xs rounded flex-shrink-0"
-            style={{ 
+            style={{
               backgroundColor: 'var(--stash-bg-base)',
-              color: 'var(--stash-accent)' 
+              color: 'var(--stash-accent)'
             }}
           >
             {gitInfo.changes.length}
           </div>
-        </button>
-      )}
+        )}
+      </button>
 
       {/* File Tree */}
       <div className="flex-1 overflow-y-auto">

--- a/stash_ui/src/app/components/FileTree.tsx
+++ b/stash_ui/src/app/components/FileTree.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { FileNode } from '../types';
 import { ChevronRight, ChevronDown, FileText, Folder, FolderOpen, Search, Plus, GitBranch, LayoutDashboard } from 'lucide-react';
 import { UserBadge } from './UserBadge';
+import { StorePicker } from './StorePicker';
 import { GitBranchInfo } from '../mockData/gitChanges';
 
 interface FileTreeProps {
@@ -145,6 +146,7 @@ export function FileTree({ tree, selectedFile, onSelectFile, onClearSelection, o
     <div className="h-full flex flex-col" style={{ backgroundColor: 'var(--stash-bg-surface)' }}>
       {/* Header */}
       <div className="p-4 border-b" style={{ borderColor: 'var(--stash-border)' }}>
+        <StorePicker className="w-full mb-3" />
         <button
           onClick={onNewDocument}
           className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-all duration-150 mb-3"

--- a/stash_ui/src/app/components/StorePicker.tsx
+++ b/stash_ui/src/app/components/StorePicker.tsx
@@ -3,7 +3,7 @@ import { useStore } from '../StoreContext';
 
 // Minimal grouping: stores sort by (tenant_slug, slug) on the server, so
 // we just walk the list and inject a label whenever the tenant changes.
-export function StorePicker() {
+export function StorePicker({ className }: { className?: string }) {
   const { stores, current, setCurrent } = useStore();
   if (stores.length === 0) return null;
 
@@ -14,7 +14,7 @@ export function StorePicker() {
         const [t, s] = e.target.value.split('/');
         if (t && s) setCurrent(t, s);
       }}
-      className="px-2 py-1.5 rounded border text-sm"
+      className={`px-2 py-1.5 rounded border text-sm ${className ?? ''}`}
       style={{
         backgroundColor: 'var(--stash-bg-surface)',
         borderColor: 'var(--stash-border)',

--- a/stash_ui/src/app/pages/DocumentsPage.tsx
+++ b/stash_ui/src/app/pages/DocumentsPage.tsx
@@ -3,7 +3,6 @@ import { Navigate } from 'react-router';
 import { FileNode, apiTreeToFileNodes } from '../types';
 import { ConcurrentEditError } from '../../api/fetch';
 import { useStore } from '../StoreContext';
-import { StorePicker } from '../components/StorePicker';
 import { FileTree } from '../components/FileTree';
 import { DocumentViewer } from '../components/DocumentViewer';
 import { DirectoryListing } from '../components/DirectoryListing';
@@ -459,29 +458,6 @@ export function DocumentsPage() {
         </div>
 
         <div className="flex items-center gap-2">
-          <StorePicker />
-          <a
-            href="/ui/account/tokens"
-            className="px-3 py-1.5 rounded border text-sm"
-            style={{
-              borderColor: 'var(--stash-border)',
-              color: 'var(--stash-text-secondary)',
-            }}
-            title="Manage API tokens"
-          >
-            Tokens
-          </a>
-          <a
-            href="/auth/logout"
-            className="px-3 py-1.5 rounded border text-sm"
-            style={{
-              borderColor: 'var(--stash-border)',
-              color: 'var(--stash-text-secondary)',
-            }}
-            title="Sign out"
-          >
-            Sign out
-          </a>
           <button
             onClick={() => setIsLeftPanelOpen(!isLeftPanelOpen)}
             className="p-2 rounded transition-all duration-150"


### PR DESCRIPTION
## Summary

Sidebar / header cleanup driven by two missing-affordance reports:

1. **Overview link was missing in non-git stores.** The "Stash Overview" page (`OverviewContent` → `FileStatsOverview`) already rendered as the fallback when no file was selected, but the sidebar entry that navigated to it was gated on `gitInfo`, so once a file was opened there was no way back. Ungated the button so it always renders. Uses `GitBranch` (accent) when git info is present and a neutral `LayoutDashboard` otherwise; the change-count badge is still git-only.
2. **Store picker, Tokens, and Sign out crowded the top header.** Store picker moved into the sidebar above the New Document button (where it scopes the tree it controls). Tokens and Sign out anchors removed — both already had entrypoints:
   - Sign out → user dropdown ("Sign Out" in `UserBadge`).
   - Tokens → User Settings modal → "API Tokens" tab → "Open token manager" (same `/ui/account/tokens` destination).

## Files

- `stash_ui/src/app/components/FileTree.tsx` — ungate Overview button, conditional icon/color, mount `StorePicker` in the header above New Document.
- `stash_ui/src/app/components/StorePicker.tsx` — accept optional `className` so it can stretch full-width in the sidebar.
- `stash_ui/src/app/pages/DocumentsPage.tsx` — drop `StorePicker`, `Tokens` anchor, `Sign out` anchor from the top header (and the now-unused `StorePicker` import).

## Test plan

- [ ] In a store with `STASH_GIT_TRACKING=false`: Overview button renders with the dashboard icon (no badge), clicking it opens `FileStatsOverview`.
- [ ] In a store with git tracking on: Overview button renders with the GitBranch icon and the change-count badge, clicking it opens `GitOverview`.
- [ ] Sidebar header shows the store picker above the New Document button; switching stores still navigates to `/:tenant/:store`.
- [ ] Top header no longer shows Store / Tokens / Sign out; user dropdown Sign Out still hits `/auth/logout`; Account Settings → API Tokens → Open token manager still reaches `/ui/account/tokens`.

https://claude.ai/code/session_01PhkSUi8MjnhHUAnr6dAsNq