### PR TITLE
Add binary file viewer for images, PDFs, and HTML artifacts

### DIFF
--- a/stash_mcp/api.py
+++ b/stash_mcp/api.py
@@ -319,24 +319,36 @@ def create_api(
         """Read content file. Returns 304 when ``If-None-Match`` matches.
 
         Binary file types (images, PDFs) return 415 — clients should
-        fetch them from :http:get:`/api/raw/{path}` instead.
+        fetch them from the raw endpoint instead.
         """
         fs = _fs()
+        # The 415 hint preserves whatever prefix the caller used so
+        # tenant/store-scoped deployments
+        # (``/api/<tenant>/<store>/content/…``) get a matching
+        # ``/api/<tenant>/<store>/raw/…`` URL instead of a hard-coded
+        # internal route that would 404 in their context.
+        raw_hint = request.url.path.replace("/content/", "/raw/", 1)
         try:
-            # Existence/path validation runs before the binary-type guard
-            # so a missing ``.png`` still 404s instead of 415-ing as if
-            # it were present.
-            if not fs.file_exists(path):
-                # ``file_exists`` swallows ``InvalidPathError`` — re-resolve
-                # to surface a 400 for traversal etc.
-                fs._resolve_path(path)
+            # Disambiguate "doesn't exist" (404) from "is a directory"
+            # (400) before the binary-type guard so a missing ``.png``
+            # still 404s and ``GET /api/content/<dir>`` still 400s.
+            try:
+                full_path = fs._resolve_path(path)
+            except InvalidPathError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            if not full_path.exists():
                 raise HTTPException(status_code=404, detail="File not found")
+            if not full_path.is_file():
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Path '{path}' is not a file",
+                )
             if _is_binary_path(path):
                 raise HTTPException(
                     status_code=415,
                     detail=(
                         f"File '{path}' is binary; fetch raw bytes from "
-                        f"/api/raw/{path}"
+                        f"{raw_hint}"
                     ),
                 )
             content = fs.read_file(path)
@@ -364,7 +376,7 @@ def create_api(
                 status_code=415,
                 detail=(
                     f"File '{path}' is not UTF-8 text; fetch raw bytes "
-                    f"from /api/raw/{path}"
+                    f"from {raw_hint}"
                 ),
             )
         except Exception as e:
@@ -375,10 +387,27 @@ def create_api(
     async def read_raw(path: str, request: Request):
         """Stream raw file bytes with the correct ``Content-Type``.
 
-        Used by the UI to render images, PDFs, and HTML artifacts that
-        the JSON content endpoint cannot represent. Honours
-        ``If-None-Match`` so the browser can cache aggressively.
+        Used by the UI to render images and PDFs that the JSON content
+        endpoint cannot represent. Honours ``If-None-Match`` so the
+        browser can cache aggressively.
+
+        Every response carries ``Content-Security-Policy: sandbox`` so
+        that if a user opens the raw URL directly (or it's linked from
+        outside the UI), executable content like ``.html`` or
+        ``.svg`` runs in an opaque origin without access to the
+        Stash session cookies, ``localStorage``, or the API. Inert
+        contexts (``<img>``, PDF ``<iframe>``) are unaffected — CSP
+        sandbox only kicks in when the response becomes a top-level
+        document.
         """
+        # Bare ``sandbox`` (no allowances) blocks scripts, forms,
+        # popups, top-level navigation, and forces an opaque origin.
+        # ``nosniff`` keeps browsers from MIME-promoting a stored
+        # ``.txt`` into ``text/html``.
+        raw_security_headers = {
+            "Content-Security-Policy": "sandbox",
+            "X-Content-Type-Options": "nosniff",
+        }
         fs = _fs()
         try:
             full_path = fs._resolve_path(path)
@@ -389,11 +418,14 @@ def create_api(
             etag = _etag(path)
             quoted = _quoted(etag)
             if _if_none_match_matches(request.headers.get("if-none-match"), etag):
-                return Response(status_code=304, headers={"ETag": quoted})
+                return Response(
+                    status_code=304,
+                    headers={"ETag": quoted, **raw_security_headers},
+                )
             return FileResponse(
                 full_path,
                 media_type=_get_mime_type(path),
-                headers={"ETag": quoted},
+                headers={"ETag": quoted, **raw_security_headers},
             )
         except HTTPException:
             raise

--- a/stash_mcp/api.py
+++ b/stash_mcp/api.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from .config import Config
@@ -18,7 +19,7 @@ from .filesystem import (
     FileSystemError,
     InvalidPathError,
 )
-from .mcp_server import MIME_TYPES
+from .mcp_server import BINARY_EXTENSIONS, MIME_TYPES
 from .metrics import get_metrics
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,16 @@ def _get_mime_type(path: str) -> str:
     """Get mime type for a file path based on extension."""
     suffix = PurePosixPath(path).suffix.lower()
     return MIME_TYPES.get(suffix, "text/plain")
+
+
+def _is_binary_path(path: str) -> bool:
+    """Return True when this path's extension is known-binary (image, PDF, …).
+
+    Binary files cannot be decoded as UTF-8, so the JSON ``/api/content``
+    endpoint surfaces a 415 and clients are expected to fetch the bytes
+    from ``/api/raw/{path}`` instead.
+    """
+    return PurePosixPath(path).suffix.lower() in BINARY_EXTENSIONS
 
 
 class ContentItem(BaseModel):
@@ -305,7 +316,19 @@ def create_api(
 
     @app.get("/api/content/{path:path}")
     async def read_content(path: str, request: Request, response: Response):
-        """Read content file. Returns 304 when ``If-None-Match`` matches."""
+        """Read content file. Returns 304 when ``If-None-Match`` matches.
+
+        Binary file types (images, PDFs) return 415 — clients should
+        fetch them from :http:get:`/api/raw/{path}` instead.
+        """
+        if _is_binary_path(path):
+            raise HTTPException(
+                status_code=415,
+                detail=(
+                    f"File '{path}' is binary; fetch raw bytes from "
+                    f"/api/raw/{path}"
+                ),
+            )
         fs = _fs()
         try:
             content = fs.read_file(path)
@@ -326,8 +349,50 @@ def create_api(
             raise HTTPException(status_code=404, detail="File not found")
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except UnicodeDecodeError:
+            raise HTTPException(
+                status_code=415,
+                detail=(
+                    f"File '{path}' is not UTF-8 text; fetch raw bytes "
+                    f"from /api/raw/{path}"
+                ),
+            )
         except Exception as e:
             logger.error(f"Error reading content: {e}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @app.get("/api/raw/{path:path}")
+    async def read_raw(path: str, request: Request):
+        """Stream raw file bytes with the correct ``Content-Type``.
+
+        Used by the UI to render images, PDFs, and HTML artifacts that
+        the JSON content endpoint cannot represent. Honours
+        ``If-None-Match`` so the browser can cache aggressively.
+        """
+        fs = _fs()
+        try:
+            full_path = fs._resolve_path(path)
+            if not full_path.exists():
+                raise HTTPException(status_code=404, detail="File not found")
+            if not full_path.is_file():
+                raise HTTPException(status_code=400, detail="Path is not a file")
+            etag = _etag(path)
+            quoted = _quoted(etag)
+            if _if_none_match_matches(request.headers.get("if-none-match"), etag):
+                return Response(status_code=304, headers={"ETag": quoted})
+            return FileResponse(
+                full_path,
+                media_type=_get_mime_type(path),
+                headers={"ETag": quoted},
+            )
+        except HTTPException:
+            raise
+        except InvalidPathError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="File not found")
+        except Exception as e:
+            logger.error(f"Error reading raw content: {e}")
             raise HTTPException(status_code=500, detail="Internal server error")
 
     @app.post("/api/content/{path:path}", status_code=201)

--- a/stash_mcp/api.py
+++ b/stash_mcp/api.py
@@ -321,16 +321,24 @@ def create_api(
         Binary file types (images, PDFs) return 415 — clients should
         fetch them from :http:get:`/api/raw/{path}` instead.
         """
-        if _is_binary_path(path):
-            raise HTTPException(
-                status_code=415,
-                detail=(
-                    f"File '{path}' is binary; fetch raw bytes from "
-                    f"/api/raw/{path}"
-                ),
-            )
         fs = _fs()
         try:
+            # Existence/path validation runs before the binary-type guard
+            # so a missing ``.png`` still 404s instead of 415-ing as if
+            # it were present.
+            if not fs.file_exists(path):
+                # ``file_exists`` swallows ``InvalidPathError`` — re-resolve
+                # to surface a 400 for traversal etc.
+                fs._resolve_path(path)
+                raise HTTPException(status_code=404, detail="File not found")
+            if _is_binary_path(path):
+                raise HTTPException(
+                    status_code=415,
+                    detail=(
+                        f"File '{path}' is binary; fetch raw bytes from "
+                        f"/api/raw/{path}"
+                    ),
+                )
             content = fs.read_file(path)
             etag = _etag(path)
             quoted = _quoted(etag)
@@ -345,6 +353,8 @@ def create_api(
                 updated_at=_get_updated_at(path),
             )
             return item
+        except HTTPException:
+            raise
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="File not found")
         except InvalidPathError as e:

--- a/stash_mcp/api.py
+++ b/stash_mcp/api.py
@@ -244,6 +244,7 @@ def create_api(
             "endpoints": {
                 "list": "/api/content",
                 "read": "/api/content/{path}",
+                "raw": "/api/raw/{path}",
                 "create": "POST /api/content/{path}",
                 "update": "PUT /api/content/{path}",
                 "delete": "DELETE /api/content/{path}",
@@ -327,7 +328,16 @@ def create_api(
         # (``/api/<tenant>/<store>/content/…``) get a matching
         # ``/api/<tenant>/<store>/raw/…`` URL instead of a hard-coded
         # internal route that would 404 in their context.
-        raw_hint = request.url.path.replace("/content/", "/raw/", 1)
+        # ``StoreResolverMiddleware`` strips the tenant/store prefix
+        # before this handler runs, so ``request.url.path`` no longer
+        # contains it. The middleware stashes the original
+        # client-facing path in ``scope["stash.original_path"]``;
+        # fall back to ``request.url.path`` in legacy single-store
+        # mode (no middleware) where the two are already equal.
+        original_path = request.scope.get(
+            "stash.original_path", request.url.path
+        )
+        raw_hint = original_path.replace("/content/", "/raw/", 1)
         try:
             # Disambiguate "doesn't exist" (404) from "is a directory"
             # (400) before the binary-type guard so a missing ``.png``

--- a/stash_mcp/filesystem.py
+++ b/stash_mcp/filesystem.py
@@ -241,6 +241,12 @@ class FileSystem:
 
         try:
             return full_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Surface decode failures so the API layer can return a
+            # targeted 415 with a raw-bytes hint, rather than masking
+            # them as a generic 500. Other read errors stay wrapped
+            # in ``FileSystemError`` for the existing handlers.
+            raise
         except Exception as e:
             logger.error(f"Error reading file '{relative_path}': {e}")
             raise FileSystemError(f"Failed to read file: {e}")

--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -76,6 +76,7 @@ MIME_TYPES: dict[str, str] = {
     ".jpeg": "image/jpeg",
     ".gif": "image/gif",
     ".webp": "image/webp",
+    ".avif": "image/avif",
     ".svg": "image/svg+xml",
     ".ico": "image/x-icon",
     ".bmp": "image/bmp",
@@ -86,7 +87,7 @@ MIME_TYPES: dict[str, str] = {
 # JSON ``/api/content`` endpoint. Callers should fetch these via
 # ``/api/raw/{path}`` instead.
 BINARY_EXTENSIONS: frozenset[str] = frozenset({
-    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp", ".pdf",
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico", ".bmp", ".pdf",
 })
 
 # Only files matching this name are exposed as MCP resources.

--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -71,7 +71,23 @@ MIME_TYPES: dict[str, str] = {
     ".cfg": "text/plain",
     ".rst": "text/x-rst",
     ".log": "text/plain",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".bmp": "image/bmp",
+    ".pdf": "application/pdf",
 }
+
+# Extensions whose content cannot be safely returned as UTF-8 text by the
+# JSON ``/api/content`` endpoint. Callers should fetch these via
+# ``/api/raw/{path}`` instead.
+BINARY_EXTENSIONS: frozenset[str] = frozenset({
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp", ".pdf",
+})
 
 # Only files matching this name are exposed as MCP resources.
 # All other files remain accessible via tools and the resource template.

--- a/stash_mcp/routing/store_resolver.py
+++ b/stash_mcp/routing/store_resolver.py
@@ -158,6 +158,13 @@ class StoreResolverMiddleware:
         new_scope = dict(scope)
         new_scope["path"] = new_path
         new_scope["raw_path"] = new_path.encode("utf-8")
+        # Stash the original client-facing path so handlers can build
+        # user-facing URLs (e.g. 415 hints pointing at the raw
+        # endpoint) that still carry the tenant/store prefix. Without
+        # this, ``request.url.path`` would only show the rewritten
+        # internal path (``/api/content/...``) which would 404 if a
+        # client tried to use it directly.
+        new_scope["stash.original_path"] = path
 
         token = set_current_store(loaded)
         try:

--- a/stash_ui/src/api/client.ts
+++ b/stash_ui/src/api/client.ts
@@ -18,10 +18,12 @@ export async function getTree(tenant: string, store: string) {
 
 /** Same-origin URL (path-only, e.g. ``/api/<tenant>/<store>/raw/...``)
  * for the raw bytes of a content file. Used by the UI to render
- * images, PDFs, and HTML artifacts directly via ``<img>``,
- * ``<iframe>``, etc. — the JSON content endpoint can't represent
- * non-UTF-8 bytes. Callers that need a fully qualified URL should
- * resolve this against ``window.location.origin``. */
+ * images and PDFs directly via ``<img>`` / ``<iframe>`` — the JSON
+ * content endpoint can't represent non-UTF-8 bytes. HTML artifacts
+ * do not load through this URL: they're fetched as text and run from
+ * a same-document blob URL with a strict ``sandbox`` so the artifact
+ * can't reach the parent origin. Callers that need a fully qualified
+ * URL should resolve this against ``window.location.origin``. */
 export function rawUrl(tenant: string, store: string, path: string): string {
   const cleaned = path.replace(/^\/+/, '');
   return `${apiBase(tenant, store)}/raw/${cleaned

--- a/stash_ui/src/api/client.ts
+++ b/stash_ui/src/api/client.ts
@@ -16,10 +16,12 @@ export async function getTree(tenant: string, store: string) {
   return res.json();
 }
 
-/** Absolute URL for the raw bytes of a content file. Used by the UI to
- * render images, PDFs, and HTML artifacts directly via ``<img>``,
+/** Same-origin URL (path-only, e.g. ``/api/<tenant>/<store>/raw/...``)
+ * for the raw bytes of a content file. Used by the UI to render
+ * images, PDFs, and HTML artifacts directly via ``<img>``,
  * ``<iframe>``, etc. — the JSON content endpoint can't represent
- * non-UTF-8 bytes. */
+ * non-UTF-8 bytes. Callers that need a fully qualified URL should
+ * resolve this against ``window.location.origin``. */
 export function rawUrl(tenant: string, store: string, path: string): string {
   const cleaned = path.replace(/^\/+/, '');
   return `${apiBase(tenant, store)}/raw/${cleaned

--- a/stash_ui/src/api/client.ts
+++ b/stash_ui/src/api/client.ts
@@ -16,6 +16,18 @@ export async function getTree(tenant: string, store: string) {
   return res.json();
 }
 
+/** Absolute URL for the raw bytes of a content file. Used by the UI to
+ * render images, PDFs, and HTML artifacts directly via ``<img>``,
+ * ``<iframe>``, etc. — the JSON content endpoint can't represent
+ * non-UTF-8 bytes. */
+export function rawUrl(tenant: string, store: string, path: string): string {
+  const cleaned = path.replace(/^\/+/, '');
+  return `${apiBase(tenant, store)}/raw/${cleaned
+    .split('/')
+    .map(encodeURIComponent)
+    .join('/')}`;
+}
+
 export async function listContent(
   tenant: string,
   store: string,
@@ -154,6 +166,7 @@ export interface ApiClient {
   deleteContent: (path: string) => Promise<any>;
   moveContent: (path: string, destination: string) => Promise<any>;
   getGitOverview: () => Promise<any | null>;
+  rawUrl: (path: string) => string;
 }
 
 export function createApiClient(tenant: string, store: string): ApiClient {
@@ -170,5 +183,6 @@ export function createApiClient(tenant: string, store: string): ApiClient {
     moveContent: (path, destination) =>
       moveContent(tenant, store, path, destination),
     getGitOverview: () => getGitOverview(tenant, store),
+    rawUrl: (path) => rawUrl(tenant, store, path),
   };
 }

--- a/stash_ui/src/app/components/AppearanceSettings.tsx
+++ b/stash_ui/src/app/components/AppearanceSettings.tsx
@@ -289,10 +289,18 @@ const GROUPS: ThemeGroup[] = [
   { label: "Dark", mode: "dark", themes: THEMES.filter((t) => t.mode === "dark") },
 ];
 
+/** Custom event dispatched after a theme is applied. Components that
+ * have already-rendered output baked from CSS vars (e.g. mermaid SVGs,
+ * which inline their colors) listen for this and re-render. */
+export const THEME_CHANGE_EVENT = "stash-theme-change";
+
 export function applyTheme(theme: Theme) {
   const root = document.documentElement;
   Object.entries(theme.vars).forEach(([k, v]) => root.style.setProperty(k, v));
   localStorage.setItem("stash-theme", theme.id);
+  window.dispatchEvent(
+    new CustomEvent(THEME_CHANGE_EVENT, { detail: { themeId: theme.id, mode: theme.mode } }),
+  );
 }
 
 /** Tiny mock-UI preview rendered entirely from a theme's raw color vars */

--- a/stash_ui/src/app/components/BinaryFileViewer.tsx
+++ b/stash_ui/src/app/components/BinaryFileViewer.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+
+export type BinaryKind = 'image' | 'pdf' | 'html';
+
+const IMAGE_EXTS = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico', 'bmp', 'avif',
+]);
+
+/** Classify a file as image / pdf / html / null based on extension.
+ *
+ * SVG renders inline as an image rather than via an HTML iframe so the
+ * file's `<script>` tags (if any) don't execute against the same origin
+ * as the rest of the app. */
+export function classifyBinary(extension: string | undefined): BinaryKind | null {
+  if (!extension) return null;
+  const ext = extension.toLowerCase();
+  if (IMAGE_EXTS.has(ext)) return 'image';
+  if (ext === 'pdf') return 'pdf';
+  if (ext === 'html' || ext === 'htm') return 'html';
+  return null;
+}
+
+interface BinaryFileViewerProps {
+  kind: BinaryKind;
+  /** URL serving raw bytes for image / pdf. */
+  rawUrl: string;
+  /** Inline HTML text (for `kind === 'html'`). The HTML renders in a
+   * sandboxed iframe so it can't reach the parent origin's cookies or
+   * APIs. */
+  htmlContent?: string;
+  fileName: string;
+}
+
+/** Renders images, PDFs, and HTML artifacts inside the document
+ * viewport. Images and PDFs stream from the API's raw endpoint;
+ * HTML is injected via ``iframe srcDoc`` with a strict sandbox so
+ * the artifact runs in a null origin. */
+export function BinaryFileViewer({ kind, rawUrl, htmlContent, fileName }: BinaryFileViewerProps) {
+  if (kind === 'image') {
+    return (
+      <div
+        className="h-full w-full flex items-center justify-center overflow-auto p-8"
+        style={{ backgroundColor: 'var(--stash-bg-base)' }}
+      >
+        <img
+          src={rawUrl}
+          alt={fileName}
+          style={{
+            maxWidth: '100%',
+            maxHeight: '100%',
+            objectFit: 'contain',
+            boxShadow: '0 4px 24px rgba(0, 0, 0, 0.4)',
+            backgroundColor: 'var(--stash-bg-surface)',
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (kind === 'pdf') {
+    return (
+      <div className="h-full w-full" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
+        <iframe
+          src={rawUrl}
+          title={fileName}
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            backgroundColor: '#ffffff',
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (kind === 'html') {
+    // `allow-scripts` lets Claude artifacts run their JS; the
+    // sandbox without `allow-same-origin` puts the iframe in a null
+    // origin, so it can't read parent cookies or call the Stash API.
+    return (
+      <HtmlSandboxFrame html={htmlContent || ''} title={fileName} />
+    );
+  }
+
+  return null;
+}
+
+function HtmlSandboxFrame({ html, title }: { html: string; title: string }) {
+  // srcDoc has a length cap in some browsers and re-renders the whole
+  // document on every keystroke when the editor is open. Use a blob
+  // URL so the iframe loads once and large artifacts work reliably.
+  const [src, setSrc] = useState<string | null>(null);
+  useEffect(() => {
+    const blob = new Blob([html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    setSrc(url);
+    return () => URL.revokeObjectURL(url);
+  }, [html]);
+
+  return (
+    <div className="h-full w-full" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
+      {src && (
+        <iframe
+          src={src}
+          title={title}
+          sandbox="allow-scripts allow-forms allow-popups allow-modals"
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            backgroundColor: '#ffffff',
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/stash_ui/src/app/components/BinaryFileViewer.tsx
+++ b/stash_ui/src/app/components/BinaryFileViewer.tsx
@@ -22,8 +22,12 @@ export function classifyBinary(extension: string | undefined): BinaryKind | null
 
 interface BinaryFileViewerProps {
   kind: BinaryKind;
-  /** URL serving raw bytes for image / pdf. */
-  rawUrl: string;
+  /** URL serving raw bytes for image / pdf. Omitted when the caller
+   * cannot build a raw URL (e.g. an API client without
+   * ``rawUrl()``) — the viewer then renders an explicit unsupported
+   * state instead of an ``<img src="">`` that would resolve to the
+   * current page. */
+  rawUrl?: string;
   /** Inline HTML text (for `kind === 'html'`). The HTML renders in a
    * sandboxed iframe so it can't reach the parent origin's cookies or
    * APIs. */
@@ -33,10 +37,13 @@ interface BinaryFileViewerProps {
 
 /** Renders images, PDFs, and HTML artifacts inside the document
  * viewport. Images and PDFs stream from the API's raw endpoint;
- * HTML is injected via ``iframe srcDoc`` with a strict sandbox so
- * the artifact runs in a null origin. */
+ * HTML is wrapped in a same-document blob URL and loaded into an
+ * iframe with a strict ``sandbox`` so the artifact runs in a null
+ * origin — blob URLs replace the legacy ``srcDoc`` approach to avoid
+ * its length cap and per-keystroke re-render. */
 export function BinaryFileViewer({ kind, rawUrl, htmlContent, fileName }: BinaryFileViewerProps) {
   if (kind === 'image') {
+    if (!rawUrl) return <UnavailableState reason="image" />;
     return (
       <div
         className="h-full w-full flex items-center justify-center overflow-auto p-8"
@@ -58,6 +65,7 @@ export function BinaryFileViewer({ kind, rawUrl, htmlContent, fileName }: Binary
   }
 
   if (kind === 'pdf') {
+    if (!rawUrl) return <UnavailableState reason="pdf" />;
     return (
       <div className="h-full w-full" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
         <iframe
@@ -84,6 +92,25 @@ export function BinaryFileViewer({ kind, rawUrl, htmlContent, fileName }: Binary
   }
 
   return null;
+}
+
+function UnavailableState({ reason }: { reason: 'image' | 'pdf' }) {
+  const label = reason === 'image' ? 'image' : 'PDF';
+  return (
+    <div
+      className="h-full w-full flex items-center justify-center p-8 text-center"
+      style={{ backgroundColor: 'var(--stash-bg-base)', color: 'var(--stash-text-secondary)' }}
+    >
+      <div>
+        <div className="text-sm font-medium" style={{ color: 'var(--stash-text-primary)' }}>
+          {label} preview unavailable
+        </div>
+        <div className="text-xs mt-1">
+          The API client cannot construct a raw URL for this file.
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function HtmlSandboxFrame({ html, title }: { html: string; title: string }) {

--- a/stash_ui/src/app/components/BinaryFileViewer.tsx
+++ b/stash_ui/src/app/components/BinaryFileViewer.tsx
@@ -6,6 +6,31 @@ const IMAGE_EXTS = new Set([
   'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico', 'bmp', 'avif',
 ]);
 
+/** Map extension → MIME type for the file kinds the binary viewer
+ * handles. Mirrors ``stash_mcp/mcp_server.py``'s ``MIME_TYPES`` for
+ * these extensions so the client can populate the metadata panel
+ * without an extra round-trip when a binary file is selected (which
+ * skips the JSON content fetch). */
+const BINARY_MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  pdf: 'application/pdf',
+  html: 'text/html',
+  htm: 'text/html',
+};
+
+export function mimeTypeForBinary(extension: string | undefined): string | undefined {
+  if (!extension) return undefined;
+  return BINARY_MIME_BY_EXT[extension.toLowerCase()];
+}
+
 /** Classify a file as image / pdf / html / null based on extension.
  *
  * SVG renders inline as an image rather than via an HTML iframe so the

--- a/stash_ui/src/app/components/DocumentViewer.tsx
+++ b/stash_ui/src/app/components/DocumentViewer.tsx
@@ -382,7 +382,7 @@ export function DocumentViewer({
         <div className="flex-1 overflow-hidden">
           <BinaryFileViewer
             kind={binaryKind}
-            rawUrl={rawUrl ? rawUrl(file.path) : ''}
+            rawUrl={rawUrl ? rawUrl(file.path) : undefined}
             htmlContent={file.content || ''}
             fileName={file.name}
           />

--- a/stash_ui/src/app/components/DocumentViewer.tsx
+++ b/stash_ui/src/app/components/DocumentViewer.tsx
@@ -15,6 +15,7 @@ import { AsyncApiViewer } from './AsyncApiViewer';
 import { DesignTokensViewer } from './DesignTokensViewer';
 import { ComponentContractViewer } from './ComponentContractViewer';
 import { ArazzoViewer } from './ArazzoViewer';
+import { BinaryFileViewer, classifyBinary } from './BinaryFileViewer';
 
 interface DocumentViewerProps {
   file: FileNode | null;
@@ -27,6 +28,10 @@ interface DocumentViewerProps {
   onSectionsChange?: (sections: Section[]) => void;
   onActiveSectionChange?: (id: string | null) => void;
   onSectionsTitleChange?: (title: string) => void;
+  /** Returns a URL the browser can fetch the raw bytes of a content
+   * file from. Used to render images and PDFs that can't go through
+   * the JSON content endpoint. */
+  rawUrl?: (path: string) => string;
 }
 
 /** Check whether an href points to an external URL. */
@@ -69,7 +74,8 @@ export function DocumentViewer({
   onActiveEndpointChange,
   onSectionsChange,
   onActiveSectionChange,
-  onSectionsTitleChange
+  onSectionsTitleChange,
+  rawUrl,
 }: DocumentViewerProps) {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [editContent, setEditContent] = useState('');
@@ -327,6 +333,63 @@ export function DocumentViewer({
   const isDesignTokens = isDesignTokensSpec();
   const isComponentContract = isComponentContractSpec();
   const isArazzo = isArazzoSpec();
+  const binaryKind = classifyBinary(file.extension);
+
+  // Images and PDFs can't round-trip through the JSON content endpoint,
+  // so view mode renders them directly from the raw bytes URL. HTML
+  // artifacts render in a sandboxed iframe but keep their text content
+  // editable.
+  const isEditable = binaryKind === 'html';
+  if (binaryKind !== null && (mode === 'view' || !isEditable)) {
+    return (
+      <div className="h-full flex flex-col" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
+        <div className="flex items-center border-b" style={{ borderColor: 'var(--stash-border)' }}>
+          <button
+            onClick={() => setMode('view')}
+            className="flex items-center gap-2 px-6 py-3 transition-all duration-150 relative"
+            style={{
+              color: 'var(--stash-text-bright)',
+              borderBottom: '2px solid var(--stash-accent)',
+            }}
+          >
+            <Eye className="w-4 h-4" />
+            <span className="text-sm">
+              {binaryKind === 'image' ? 'Image'
+                : binaryKind === 'pdf' ? 'PDF'
+                : 'HTML Preview'}
+            </span>
+          </button>
+          {isEditable && (
+            <button
+              onClick={() => setMode('edit')}
+              className="flex items-center gap-2 px-6 py-3 transition-all duration-150 relative"
+              style={{
+                color: 'var(--stash-text-secondary)',
+                borderBottom: '2px solid transparent',
+              }}
+            >
+              <Edit className="w-4 h-4" />
+              <span className="text-sm">Edit</span>
+              {hasChanges && (
+                <div
+                  className="w-2 h-2 rounded-full"
+                  style={{ backgroundColor: 'var(--stash-accent)' }}
+                />
+              )}
+            </button>
+          )}
+        </div>
+        <div className="flex-1 overflow-hidden">
+          <BinaryFileViewer
+            kind={binaryKind}
+            rawUrl={rawUrl ? rawUrl(file.path) : ''}
+            htmlContent={file.content || ''}
+            fileName={file.name}
+          />
+        </div>
+      </div>
+    );
+  }
 
   // If it's an AsyncAPI spec, render with AsyncApiViewer
   if (isAsyncApi && mode === 'view') {

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -1,209 +1,208 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import mermaid from 'mermaid';
 import { Code, ZoomIn, ZoomOut, RotateCcw, Download } from 'lucide-react';
 import { TransformWrapper, TransformComponent, useControls } from 'react-zoom-pan-pinch';
+import { THEME_CHANGE_EVENT } from './AppearanceSettings';
 
 interface MermaidDiagramProps {
   chart: string;
   className?: string;
 }
 
-// Initialize mermaid with Stash-MCP dark theme
-mermaid.initialize({
-  startOnLoad: false,
-  theme: 'base',
-  themeVariables: {
-    // Core colors
-    darkMode: true,
-    background: '#1e1e2e',
-    primaryColor: '#94e2d5',
-    primaryTextColor: '#1e1e2e',
-    primaryBorderColor: '#94e2d5',
-    lineColor: '#94e2d5',
-    secondaryColor: '#89dceb',
-    secondaryTextColor: '#1e1e2e',
-    secondaryBorderColor: '#89dceb',
-    tertiaryColor: '#cba6f7',
-    tertiaryTextColor: '#1e1e2e',
-    tertiaryBorderColor: '#cba6f7',
-    
-    // Text colors
-    textColor: '#cdd6f4',
+/** Resolve a CSS custom property off the document root. Always returns
+ * a usable color string — mermaid bakes these into the rendered SVG,
+ * so empty values would produce broken diagrams. */
+function readCssVar(name: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return value || fallback;
+}
+
+/** Relative luminance for a ``#rrggbb`` color. Used to decide whether
+ * the active theme reads as light or dark so mermaid's contrast
+ * heuristics line up with our palette. */
+function isDarkBg(hex: string): boolean {
+  const m = hex.replace(/^#/, '').match(/^[0-9a-f]{6}$/i);
+  if (!m) return true;
+  const r = parseInt(m[0].slice(0, 2), 16);
+  const g = parseInt(m[0].slice(2, 4), 16);
+  const b = parseInt(m[0].slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b < 128;
+}
+
+/** Map the active Stash theme vars to mermaid's ``themeVariables``.
+ * Called on every render so theme swaps via ``applyTheme()`` flow
+ * straight through.
+ *
+ * Node fills use surface/elevated backgrounds (not the accent), so
+ * the same accent color works as a border across the whole palette
+ * without sacrificing text contrast — the previous hardcoded mapping
+ * filled nodes with ``--stash-accent`` and then tried to read text
+ * against it, which only worked on the original teal-on-#1e1e2e
+ * palette. */
+function getMermaidThemeVariables() {
+  const bgBase = readCssVar('--stash-bg-base', '#1e1e2e');
+  const bgSurface = readCssVar('--stash-bg-surface', '#272738');
+  const bgElevated = readCssVar('--stash-bg-elevated', '#2e2e42');
+  const bgCode = readCssVar('--stash-bg-code', '#181825');
+  const textPrimary = readCssVar('--stash-text-primary', '#cdd6f4');
+  const textSecondary = readCssVar('--stash-text-secondary', '#7f849c');
+  const textBright = readCssVar('--stash-text-bright', '#e0e4f0');
+  const accent = readCssVar('--stash-accent', '#94e2d5');
+  const destructive = readCssVar('--stash-destructive', '#f38ba8');
+  const border = readCssVar('--stash-border', '#313244');
+  const dark = isDarkBg(bgBase);
+
+  return {
+    darkMode: dark,
+    background: bgBase,
+
+    primaryColor: bgElevated,
+    primaryTextColor: textPrimary,
+    primaryBorderColor: accent,
+    lineColor: textSecondary,
+    secondaryColor: bgSurface,
+    secondaryTextColor: textPrimary,
+    secondaryBorderColor: border,
+    tertiaryColor: bgCode,
+    tertiaryTextColor: textPrimary,
+    tertiaryBorderColor: border,
+
+    textColor: textPrimary,
     fontSize: '16px',
     fontFamily: 'ui-sans-serif, system-ui, sans-serif',
-    
-    // Background colors
-    mainBkg: '#2e2e42',
-    secondBkg: '#272738',
-    tertiaryBkg: '#353550',
-    
-    // Border colors
-    border1: '#94e2d5',
-    border2: '#89dceb',
-    
-    // Node/box styling
-    nodeBorder: '#94e2d5',
-    nodeTextColor: '#cdd6f4',
-    clusterBkg: '#272738',
-    clusterBorder: '#94e2d5',
-    defaultLinkColor: '#94e2d5',
-    titleColor: '#cdd6f4',
-    edgeLabelBackground: '#1e1e2e',
-    
-    // Specific diagram colors - Sequence Diagrams
-    actorBorder: '#94e2d5',
-    actorBkg: '#2e2e42',
-    actorTextColor: '#cdd6f4',
-    actorLineColor: '#94e2d5',
-    signalColor: '#cdd6f4',
-    signalTextColor: '#cdd6f4',
-    labelBoxBkgColor: '#2e2e42',
-    labelBoxBorderColor: '#94e2d5',
-    labelTextColor: '#cdd6f4',
-    loopTextColor: '#cdd6f4',
-    noteBorderColor: '#f9e2af',
-    noteBkgColor: '#2e2e42',
-    noteTextColor: '#f9e2af',
-    activationBorderColor: '#94e2d5',
-    activationBkgColor: '#94e2d5',
-    sequenceNumberColor: '#1e1e2e',
-    
-    // State diagram
-    labelColor: '#1e1e2e',
-    
-    // Git graph
-    git0: '#94e2d5',
-    git1: '#89dceb',
-    git2: '#f38ba8',
-    git3: '#f9e2af',
-    git4: '#cba6f7',
-    git5: '#a6e3a1',
-    git6: '#fab387',
-    git7: '#f5c2e7',
-    gitBranchLabel0: '#1e1e2e',
-    gitBranchLabel1: '#1e1e2e',
-    gitBranchLabel2: '#1e1e2e',
-    gitBranchLabel3: '#1e1e2e',
-    gitBranchLabel4: '#1e1e2e',
-    gitBranchLabel5: '#1e1e2e',
-    gitBranchLabel6: '#1e1e2e',
-    gitBranchLabel7: '#1e1e2e',
-    gitInv0: '#1e1e2e',
-    gitInv1: '#1e1e2e',
-    gitInv2: '#1e1e2e',
-    gitInv3: '#1e1e2e',
-    gitInv4: '#1e1e2e',
-    gitInv5: '#1e1e2e',
-    gitInv6: '#1e1e2e',
-    gitInv7: '#1e1e2e',
-    commitLabelColor: '#cdd6f4',
-    commitLabelBackground: '#2e2e42',
-    
-    // Pie chart
-    pie1: '#94e2d5',
-    pie2: '#89dceb',
-    pie3: '#f38ba8',
-    pie4: '#f9e2af',
-    pie5: '#cba6f7',
-    pie6: '#a6e3a1',
-    pie7: '#fab387',
-    pie8: '#f5c2e7',
-    pie9: '#b4befe',
-    pie10: '#f2cdcd',
-    pie11: '#eba0ac',
-    pie12: '#74c7ec',
+
+    mainBkg: bgElevated,
+    secondBkg: bgSurface,
+    tertiaryBkg: bgCode,
+
+    border1: border,
+    border2: accent,
+
+    nodeBorder: accent,
+    nodeTextColor: textPrimary,
+    clusterBkg: bgSurface,
+    clusterBorder: border,
+    defaultLinkColor: textSecondary,
+    titleColor: textBright,
+    edgeLabelBackground: bgBase,
+
+    // Sequence diagrams
+    actorBorder: accent,
+    actorBkg: bgElevated,
+    actorTextColor: textPrimary,
+    actorLineColor: textSecondary,
+    signalColor: textPrimary,
+    signalTextColor: textPrimary,
+    labelBoxBkgColor: bgElevated,
+    labelBoxBorderColor: accent,
+    labelTextColor: textPrimary,
+    loopTextColor: textPrimary,
+    noteBorderColor: accent,
+    noteBkgColor: bgSurface,
+    noteTextColor: textPrimary,
+    activationBorderColor: accent,
+    activationBkgColor: accent,
+    sequenceNumberColor: bgBase,
+
+    // State / class diagrams
+    labelColor: textPrimary,
+    classText: textPrimary,
+
+    // Git graph — branch lanes rotate through the accent + a few
+    // theme-neutral hues so multi-branch graphs stay legible. Branch
+    // labels render against ``--stash-bg-base`` so they read the same
+    // in light and dark themes.
+    git0: accent,
+    git1: textSecondary,
+    git2: destructive,
+    git3: textBright,
+    git4: border,
+    git5: accent,
+    git6: textSecondary,
+    git7: destructive,
+    gitBranchLabel0: bgBase,
+    gitBranchLabel1: bgBase,
+    gitBranchLabel2: bgBase,
+    gitBranchLabel3: bgBase,
+    gitBranchLabel4: bgBase,
+    gitBranchLabel5: bgBase,
+    gitBranchLabel6: bgBase,
+    gitBranchLabel7: bgBase,
+    commitLabelColor: textPrimary,
+    commitLabelBackground: bgElevated,
+
+    // Pie charts
+    pie1: accent,
+    pie2: textSecondary,
+    pie3: destructive,
+    pie4: textBright,
+    pie5: border,
+    pie6: accent,
+    pie7: textSecondary,
+    pie8: destructive,
     pieTitleTextSize: '24px',
-    pieTitleTextColor: '#cdd6f4',
+    pieTitleTextColor: textBright,
     pieSectionTextSize: '16px',
-    pieSectionTextColor: '#1e1e2e',
+    pieSectionTextColor: textPrimary,
     pieLegendTextSize: '14px',
-    pieLegendTextColor: '#cdd6f4',
-    pieStrokeColor: '#1e1e2e',
+    pieLegendTextColor: textPrimary,
+    pieStrokeColor: bgBase,
     pieStrokeWidth: '2px',
     pieOpacity: '0.95',
-    
-    // Flowchart
-    fillType0: '#94e2d5',
-    fillType1: '#89dceb',
-    fillType2: '#cba6f7',
-    fillType3: '#f9e2af',
-    fillType4: '#a6e3a1',
-    fillType5: '#fab387',
-    fillType6: '#f38ba8',
-    fillType7: '#f5c2e7',
-    
-    // Class diagram
-    classText: '#1e1e2e',
-    
-    // ER diagram
-    attributeBackgroundColorOdd: '#2e2e42',
-    attributeBackgroundColorEven: '#272738',
-    entityBackgroundColor: '#2e2e42',
-    entityBorderColor: '#94e2d5',
-    entityTextColor: '#cdd6f4',
-    relationLabelColor: '#cdd6f4',
-    relationLabelBackground: '#1e1e2e',
-    relationColor: '#94e2d5',
-    attributeTextColor: '#cdd6f4',
-    labelBackground: '#1e1e2e',
-    
-    // Timeline
-    cScale0: '#94e2d5',
-    cScale1: '#2e2e42',
-    cScale2: '#89dceb',
-    cScale3: '#2e2e42',
-    cScale4: '#f38ba8',
-    cScale5: '#2e2e42',
-    cScale6: '#f9e2af',
-    cScale7: '#2e2e42',
-    cScale8: '#cba6f7',
-    cScale9: '#2e2e42',
-    cScale10: '#a6e3a1',
-    cScale11: '#2e2e42',
-    cScaleLabel0: '#1e1e2e',
-    cScaleLabel1: '#cdd6f4',
-    cScaleLabel2: '#1e1e2e',
-    cScaleLabel3: '#cdd6f4',
-    cScaleLabel4: '#1e1e2e',
-    cScaleLabel5: '#cdd6f4',
-    cScaleLabel6: '#1e1e2e',
-    cScaleLabel7: '#cdd6f4',
-    cScaleLabel8: '#1e1e2e',
-    cScaleLabel9: '#cdd6f4',
-    cScaleLabel10: '#1e1e2e',
-    cScaleLabel11: '#cdd6f4',
-  },
-  fontFamily: 'ui-sans-serif, system-ui, sans-serif',
-  fontSize: 16,
-  flowchart: {
-    htmlLabels: true,
-    curve: 'basis',
-  },
-  sequence: {
-    diagramMarginX: 50,
-    diagramMarginY: 10,
-    actorMargin: 50,
-    width: 150,
-    height: 65,
-    boxMargin: 10,
-    boxTextMargin: 5,
-    noteMargin: 10,
-    messageMargin: 35,
-    mirrorActors: true,
-    useMaxWidth: true,
-  },
-  gantt: {
-    titleTopMargin: 25,
-    barHeight: 20,
-    barGap: 4,
-    topPadding: 50,
-    leftPadding: 75,
-    gridLineStartPadding: 35,
-    fontSize: 11,
-    numberSectionStyles: 4,
-    axisFormat: '%Y-%m-%d',
-  },
-});
+
+    // ER diagrams
+    attributeBackgroundColorOdd: bgElevated,
+    attributeBackgroundColorEven: bgSurface,
+    entityBackgroundColor: bgElevated,
+    entityBorderColor: accent,
+    entityTextColor: textPrimary,
+    relationLabelColor: textPrimary,
+    relationLabelBackground: bgBase,
+    relationColor: textSecondary,
+    attributeTextColor: textPrimary,
+    labelBackground: bgBase,
+  };
+}
+
+function initializeMermaid() {
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: 'base',
+    themeVariables: getMermaidThemeVariables(),
+    fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+    fontSize: 16,
+    flowchart: { htmlLabels: true, curve: 'basis' },
+    sequence: {
+      diagramMarginX: 50,
+      diagramMarginY: 10,
+      actorMargin: 50,
+      width: 150,
+      height: 65,
+      boxMargin: 10,
+      boxTextMargin: 5,
+      noteMargin: 10,
+      messageMargin: 35,
+      mirrorActors: true,
+      useMaxWidth: true,
+    },
+    gantt: {
+      titleTopMargin: 25,
+      barHeight: 20,
+      barGap: 4,
+      topPadding: 50,
+      leftPadding: 75,
+      gridLineStartPadding: 35,
+      fontSize: 11,
+      numberSectionStyles: 4,
+      axisFormat: '%Y-%m-%d',
+    },
+  });
+}
+
+initializeMermaid();
 
 // Controls component that uses the useControls hook
 function DiagramControls({ onDownload }: { onDownload: () => void }) {
@@ -299,6 +298,16 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
   const [svg, setSvg] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [showSource, setShowSource] = useState(false);
+  // Bumped on theme swaps to force a re-init + re-render of the SVG.
+  // Mermaid bakes colors into the SVG at render time, so swapping
+  // CSS vars alone won't re-color an already-rendered diagram.
+  const [themeNonce, setThemeNonce] = useState(0);
+
+  useEffect(() => {
+    const handler = () => setThemeNonce((n) => n + 1);
+    window.addEventListener(THEME_CHANGE_EVENT, handler);
+    return () => window.removeEventListener(THEME_CHANGE_EVENT, handler);
+  }, []);
 
   const handleDownload = () => {
     const svgData = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
@@ -318,41 +327,42 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
 
       try {
         setError('');
+        // Re-init with the current theme vars so a swap takes effect
+        // here even when the module-level call ran with an earlier
+        // palette.
+        initializeMermaid();
         const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
-        
+
         const { svg: renderedSvg } = await mermaid.render(id, chart);
-        
-        // Apply comprehensive CSS fixes for text visibility across all diagram types
-        let fixedSvg = renderedSvg;
-        
-        // Force text color to be visible across ALL diagram types
-        fixedSvg = fixedSvg.replace(
-          /<style>/,
-          `<style>
-            /* Universal text visibility fixes */
-            text {
-              fill: #cdd6f4 !important;
-            }
-            
-            /* Timeline - ensure text visibility in boxes */
+
+        // Layer a small theme-aware stylesheet on top of mermaid's
+        // output. ``themeVariables`` covers most of the palette, but
+        // a few diagram types (timeline, gantt, flowchart HTML
+        // labels) inline classes that need an explicit fill.
+        const bgBase = readCssVar('--stash-bg-base', '#1e1e2e');
+        const textPrimary = readCssVar('--stash-text-primary', '#cdd6f4');
+        const textBright = readCssVar('--stash-text-bright', '#e0e4f0');
+        const overrides = `
+            /* Timeline event labels render on accent-colored fills —
+             * force a dark on-color so they stay legible on light themes
+             * too. Section titles read against the page background. */
             .timeline .event rect + text,
             .timeline text {
-              fill: #1e1e2e !important;
+              fill: ${bgBase} !important;
               font-weight: 600 !important;
             }
-            
-            /* Timeline section titles */
             .timeline .section0 text,
             .timeline .section1 text,
             .timeline .section2 text,
             .timeline .section3 text,
             .timeline .section {
-              fill: #cdd6f4 !important;
+              fill: ${textBright} !important;
               font-weight: 700 !important;
               font-size: 18px !important;
             }
-            
-            /* Gantt Charts - specific fixes for task labels */
+
+            /* Gantt task labels sit on filled bars (always tinted by
+             * the active accent), axis labels sit on the page. */
             .taskText,
             .taskTextOutsideRight,
             .taskTextOutsideLeft,
@@ -362,59 +372,30 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
             .taskText3,
             .sectionTitle,
             .titleText {
-              fill: #1e1e2e !important;
+              fill: ${bgBase} !important;
               font-weight: 500 !important;
             }
-            
-            /* Gantt axis labels */
             .tick text {
-              fill: #cdd6f4 !important;
+              fill: ${textPrimary} !important;
             }
-            
-            /* ER Diagrams */
-            .er.attributeBoxOdd text, 
-            .er.attributeBoxEven text,
-            .er .entityLabel text,
-            .er text {
-              fill: #cdd6f4 !important;
-            }
-            
-            /* State Diagrams */
-            .statediagram-state rect.basic + text,
-            .statediagram-state text,
-            g.stateGroup text,
-            .state-note text {
-              fill: #cdd6f4 !important;
-            }
-            
-            /* Flowcharts */
+
+            /* Flowchart HTML labels (htmlLabels: true) live inside
+             * foreignObjects and inherit page color, not SVG fill. */
+            .node .nodeLabel,
             .node text,
-            .nodeLabel,
+            .edgeLabel,
             .edgeLabel text,
             foreignObject div {
-              color: #cdd6f4 !important;
-              fill: #cdd6f4 !important;
+              color: ${textPrimary} !important;
+              fill: ${textPrimary} !important;
             }
-            
-            /* Class Diagrams */
-            .classLabel text,
-            .classTitle text {
-              fill: #cdd6f4 !important;
-            }
-            
-            /* Edge labels and transitions */
-            .edgeLabel,
-            .transition text {
-              fill: #cdd6f4 !important;
-            }
-            
-            /* Cluster/Subgraph labels */
+
             .cluster-label text {
-              fill: #cdd6f4 !important;
+              fill: ${textPrimary} !important;
             }
-          `
-        );
-        
+          `;
+        const fixedSvg = renderedSvg.replace(/<style>/, `<style>${overrides}`);
+
         setSvg(fixedSvg);
       } catch (err) {
         console.error('Mermaid rendering error:', err);
@@ -423,7 +404,7 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
     };
 
     renderDiagram();
-  }, [chart]);
+  }, [chart, themeNonce]);
 
   if (error) {
     return (

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -37,7 +37,11 @@ function parseLuminance(color: string): number | null {
   let b = 0;
   const longHex = c.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/);
   const shortHex = c.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
-  const rgb = c.match(/^rgba?\(\s*([\d.]+)[ ,]+([\d.]+)[ ,]+([\d.]+)/);
+  // Optional 4th group captures alpha in either ``rgba(r, g, b, a)``
+  // or CSS Color Level 4 ``rgb(r g b / a)`` form.
+  const rgb = c.match(
+    /^rgba?\(\s*([\d.]+)[ ,]+([\d.]+)[ ,]+([\d.]+)(?:\s*[,/]\s*([\d.]+%?))?/,
+  );
   if (longHex) {
     r = parseInt(longHex[1], 16);
     g = parseInt(longHex[2], 16);
@@ -47,6 +51,18 @@ function parseLuminance(color: string): number | null {
     g = parseInt(shortHex[2] + shortHex[2], 16);
     b = parseInt(shortHex[3] + shortHex[3], 16);
   } else if (rgb) {
+    // Treat noticeably translucent fills as unparseable. The final
+    // rendered color depends on whatever sits behind the node (the
+    // diagram background, another shape, the page) which we can't
+    // see from here — picking a contrast color from the rgb channels
+    // alone would be wrong (e.g. ``rgba(255,255,255,0.05)`` on a
+    // dark theme would force dark text onto an effectively dark
+    // pixel). Caller leaves the existing text alone.
+    if (rgb[4] !== undefined) {
+      const raw = rgb[4];
+      const alpha = raw.endsWith('%') ? parseFloat(raw) / 100 : parseFloat(raw);
+      if (!Number.isFinite(alpha) || alpha < 0.85) return null;
+    }
     r = parseFloat(rgb[1]);
     g = parseFloat(rgb[2]);
     b = parseFloat(rgb[3]);

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import mermaid from 'mermaid';
 import { Code, ZoomIn, ZoomOut, RotateCcw, Download } from 'lucide-react';
-import { TransformWrapper, TransformComponent, useControls } from 'react-zoom-pan-pinch';
+import {
+  TransformWrapper,
+  TransformComponent,
+  useControls,
+  type ReactZoomPanPinchRef,
+} from 'react-zoom-pan-pinch';
 import { THEME_CHANGE_EVENT } from './AppearanceSettings';
 
 interface MermaidDiagramProps {
@@ -373,6 +378,8 @@ function DiagramControls({ onDownload }: { onDownload: () => void }) {
 
 export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const transformApiRef = useRef<ReactZoomPanPinchRef | null>(null);
   const [svg, setSvg] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [showSource, setShowSource] = useState(false);
@@ -386,6 +393,43 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
     window.addEventListener(THEME_CHANGE_EVENT, handler);
     return () => window.removeEventListener(THEME_CHANGE_EVENT, handler);
   }, []);
+
+  // Fit-on-load: measure the rendered SVG against the viewport and
+  // pick an initial zoom so small diagrams stay at 1:1 (don't blow up
+  // to fill 500px of vertical space) while large diagrams scale down
+  // to fit. Runs after every re-render of the SVG markup, including
+  // theme swaps and ``showSource`` toggles. The user's manual
+  // zoom/pan resets when the SVG itself changes — re-fitting is the
+  // intended behaviour, otherwise stale transforms would point at
+  // empty space.
+  useEffect(() => {
+    if (!svg) return;
+    const raf = requestAnimationFrame(() => {
+      const api = transformApiRef.current;
+      const viewport = viewportRef.current;
+      const svgEl = containerRef.current?.querySelector('svg');
+      if (!api || !viewport || !svgEl) return;
+      const vb = svgEl.viewBox?.baseVal;
+      const naturalW = vb && vb.width
+        ? vb.width
+        : svgEl.getBoundingClientRect().width;
+      const naturalH = vb && vb.height
+        ? vb.height
+        : svgEl.getBoundingClientRect().height;
+      if (!naturalW || !naturalH) return;
+      // 0.95 leaves a little breathing room around the diagram so it
+      // doesn't kiss the viewport edges. Capped at 1.0 so a 2-node
+      // flowchart doesn't render with 80px text.
+      const fit = Math.min(
+        viewport.offsetWidth / naturalW,
+        viewport.offsetHeight / naturalH,
+        1,
+      );
+      const scale = Math.max(fit * 0.95, 0.1);
+      api.centerView(scale, 0);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [svg]);
 
   const handleDownload = () => {
     const svgData = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
@@ -583,8 +627,9 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
       )}
 
       {/* Rendered diagram with zoom controls */}
-      <div className="relative" style={{ minHeight: '500px' }}>
+      <div ref={viewportRef} className="relative" style={{ minHeight: '500px' }}>
         <TransformWrapper
+          ref={transformApiRef}
           initialScale={1}
           minScale={0.1}
           maxScale={5}

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -20,16 +20,94 @@ function readCssVar(name: string, fallback: string): string {
   return value || fallback;
 }
 
-/** Relative luminance for a ``#rrggbb`` color. Used to decide whether
- * the active theme reads as light or dark so mermaid's contrast
- * heuristics line up with our palette. */
+/** Relative luminance for any CSS color string mermaid embeds in the
+ * rendered SVG (``#rgb``, ``#rrggbb``, or ``rgb()``/``rgba()``).
+ * Returns ``null`` for ``none`` / ``transparent`` / unparseable so
+ * callers can leave text alone in that case. */
+function parseLuminance(color: string): number | null {
+  const c = color.trim().toLowerCase();
+  if (!c || c === 'none' || c === 'transparent') return null;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  const longHex = c.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/);
+  const shortHex = c.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
+  const rgb = c.match(/^rgba?\(\s*([\d.]+)[ ,]+([\d.]+)[ ,]+([\d.]+)/);
+  if (longHex) {
+    r = parseInt(longHex[1], 16);
+    g = parseInt(longHex[2], 16);
+    b = parseInt(longHex[3], 16);
+  } else if (shortHex) {
+    r = parseInt(shortHex[1] + shortHex[1], 16);
+    g = parseInt(shortHex[2] + shortHex[2], 16);
+    b = parseInt(shortHex[3] + shortHex[3], 16);
+  } else if (rgb) {
+    r = parseFloat(rgb[1]);
+    g = parseFloat(rgb[2]);
+    b = parseFloat(rgb[3]);
+  } else {
+    return null;
+  }
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
 function isDarkBg(hex: string): boolean {
-  const m = hex.replace(/^#/, '').match(/^[0-9a-f]{6}$/i);
-  if (!m) return true;
-  const r = parseInt(m[0].slice(0, 2), 16);
-  const g = parseInt(m[0].slice(2, 4), 16);
-  const b = parseInt(m[0].slice(4, 6), 16);
-  return 0.299 * r + 0.587 * g + 0.114 * b < 128;
+  const lum = parseLuminance(hex);
+  return lum === null ? true : lum < 0.5;
+}
+
+/** Mermaid bakes a single ``textColor`` into the SVG for all node
+ * text, but a diagram author can override individual node fills with
+ * ``classDef``. When that fill happens to clash with the theme's text
+ * color (e.g. a pale ``classDef`` fill on a dark theme), the labels
+ * become unreadable.
+ *
+ * This walks the rendered SVG, reads each node's actual ``fill``
+ * (attribute or inline style), and forces the text inside to a
+ * guaranteed-contrasting near-black or near-white. Always-fixed
+ * contrast colors (not theme vars) so light/cream fills work on dark
+ * themes too. */
+function applyNodeTextContrast(svgMarkup: string): string {
+  if (typeof DOMParser === 'undefined') return svgMarkup;
+  const doc = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml');
+  if (doc.querySelector('parsererror')) return svgMarkup;
+
+  const ON_LIGHT = '#11151c';
+  const ON_DARK = '#e0e4f0';
+
+  const nodes = doc.querySelectorAll(
+    'g.node, g.actor, g.cluster, g.statediagram-cluster, g.classGroup',
+  );
+  nodes.forEach((node) => {
+    const shape = node.querySelector(
+      ':scope > rect, :scope > circle, :scope > polygon, :scope > path, :scope > ellipse, :scope > .basic, :scope > .label-container',
+    ) as SVGElement | null;
+    if (!shape) return;
+    const inline = shape.getAttribute('style') || '';
+    const fillFromStyle = inline.match(/(?:^|[;\s])fill\s*:\s*([^;]+)/i)?.[1];
+    const fill = (fillFromStyle || shape.getAttribute('fill') || '').trim();
+    const lum = parseLuminance(fill);
+    if (lum === null) return;
+    const textColor = lum > 0.55 ? ON_LIGHT : ON_DARK;
+
+    node.querySelectorAll('text, tspan').forEach((el) => {
+      (el as SVGElement).setAttribute('fill', textColor);
+      // Some mermaid versions emit ``style="fill: …"`` too — keep
+      // the attribute and inline style aligned.
+      const existing = (el as SVGElement).getAttribute('style') || '';
+      (el as SVGElement).setAttribute(
+        'style',
+        `${existing.replace(/(?:^|[;\s])fill\s*:[^;]+;?/i, '')};fill:${textColor}`,
+      );
+    });
+    node
+      .querySelectorAll('foreignObject div, foreignObject span, foreignObject p')
+      .forEach((el) => {
+        (el as HTMLElement).style.color = textColor;
+      });
+  });
+
+  return new XMLSerializer().serializeToString(doc);
 }
 
 /** Map the active Stash theme vars to mermaid's ``themeVariables``.
@@ -337,8 +415,11 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
 
         // Layer a small theme-aware stylesheet on top of mermaid's
         // output. ``themeVariables`` covers most of the palette, but
-        // a few diagram types (timeline, gantt, flowchart HTML
-        // labels) inline classes that need an explicit fill.
+        // a few diagram types (timeline, gantt) inline classes that
+        // need an explicit fill against their accent-tinted bars.
+        // Node label text is handled per-node by ``applyNodeTextContrast``
+        // (further down) so authored ``classDef`` fills get a
+        // contrast-matched text color regardless of the active theme.
         const bgBase = readCssVar('--stash-bg-base', '#1e1e2e');
         const textPrimary = readCssVar('--stash-text-primary', '#cdd6f4');
         const textBright = readCssVar('--stash-text-bright', '#e0e4f0');
@@ -379,22 +460,15 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
               fill: ${textPrimary} !important;
             }
 
-            /* Flowchart HTML labels (htmlLabels: true) live inside
-             * foreignObjects and inherit page color, not SVG fill. */
-            .node .nodeLabel,
-            .node text,
+            /* Edge labels sit on the page background, not on a node fill. */
             .edgeLabel,
-            .edgeLabel text,
-            foreignObject div {
-              color: ${textPrimary} !important;
-              fill: ${textPrimary} !important;
-            }
-
-            .cluster-label text {
-              fill: ${textPrimary} !important;
+            .edgeLabel text {
+              color: ${textPrimary};
+              fill: ${textPrimary};
             }
           `;
-        const fixedSvg = renderedSvg.replace(/<style>/, `<style>${overrides}`);
+        const styledSvg = renderedSvg.replace(/<style>/, `<style>${overrides}`);
+        const fixedSvg = applyNodeTextContrast(styledSvg);
 
         setSvg(fixedSvg);
       } catch (err) {

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -654,6 +654,9 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
           minScale={0.1}
           maxScale={5}
           centerOnInit
+          limitToBounds={false}
+          centerZoomedOut={false}
+          alignmentAnimation={{ disabled: true, sizeX: 0, sizeY: 0 }}
           wheel={{ step: 0.05 }}
           doubleClick={{ disabled: false, mode: 'zoomIn', step: 0.7 }}
           panning={{ velocityDisabled: true }}

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -77,6 +77,26 @@ function applyNodeTextContrast(svgMarkup: string): string {
   const doc = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml');
   if (doc.querySelector('parsererror')) return svgMarkup;
 
+  // Mermaid emits ``<svg width="100%" style="max-width: Npx">`` —
+  // inside ``react-zoom-pan-pinch``'s transformed content area, which
+  // has no defined width, ``width="100%"`` resolves to 0px and the
+  // SVG collapses to nothing. Rewrite to explicit viewBox dimensions
+  // so the content component has a real natural size to measure
+  // against when we call ``centerView()`` below.
+  const svgRoot = doc.querySelector('svg');
+  const vb = svgRoot?.viewBox?.baseVal;
+  if (svgRoot && vb && vb.width > 0 && vb.height > 0) {
+    svgRoot.setAttribute('width', String(vb.width));
+    svgRoot.setAttribute('height', String(vb.height));
+    const style = svgRoot.getAttribute('style') || '';
+    const cleaned = style
+      .replace(/(?:^|;)\s*max-width\s*:[^;]+/gi, '')
+      .replace(/^\s*;\s*/, '')
+      .trim();
+    if (cleaned) svgRoot.setAttribute('style', cleaned);
+    else svgRoot.removeAttribute('style');
+  }
+
   const ON_LIGHT = '#11151c';
   const ON_DARK = '#e0e4f0';
 

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import mermaid from 'mermaid';
 import { Code, ZoomIn, ZoomOut, RotateCcw, Download } from 'lucide-react';
 import {
@@ -308,8 +308,14 @@ function initializeMermaid() {
 initializeMermaid();
 
 // Controls component that uses the useControls hook
-function DiagramControls({ onDownload }: { onDownload: () => void }) {
-  const { zoomIn, zoomOut, resetTransform } = useControls();
+function DiagramControls({
+  onDownload,
+  onReset,
+}: {
+  onDownload: () => void;
+  onReset: () => void;
+}) {
+  const { zoomIn, zoomOut } = useControls();
 
   return (
     <div
@@ -353,7 +359,7 @@ function DiagramControls({ onDownload }: { onDownload: () => void }) {
         <ZoomOut className="w-4 h-4" />
       </button>
       <button
-        onClick={() => resetTransform()}
+        onClick={onReset}
         className="p-1.5 rounded transition-colors duration-150"
         style={{ color: 'var(--stash-text-secondary)' }}
         onMouseEnter={(e) => {
@@ -414,42 +420,41 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
     return () => window.removeEventListener(THEME_CHANGE_EVENT, handler);
   }, []);
 
-  // Fit-on-load: measure the rendered SVG against the viewport and
-  // pick an initial zoom so small diagrams stay at 1:1 (don't blow up
-  // to fill 500px of vertical space) while large diagrams scale down
-  // to fit. Runs after every re-render of the SVG markup, including
-  // theme swaps and ``showSource`` toggles. The user's manual
-  // zoom/pan resets when the SVG itself changes — re-fitting is the
-  // intended behaviour, otherwise stale transforms would point at
-  // empty space.
+  // Measure the rendered SVG against the viewport and pick a zoom
+  // that fits with a little breathing room. Capped at 1.0 so a small
+  // 2-node flowchart doesn't blow up to fill 500px of vertical space
+  // with 80px text.
+  const fitToViewport = useCallback(() => {
+    const api = transformApiRef.current;
+    const viewport = viewportRef.current;
+    const svgEl = containerRef.current?.querySelector('svg');
+    if (!api || !viewport || !svgEl) return;
+    const vb = svgEl.viewBox?.baseVal;
+    const naturalW = vb && vb.width
+      ? vb.width
+      : svgEl.getBoundingClientRect().width;
+    const naturalH = vb && vb.height
+      ? vb.height
+      : svgEl.getBoundingClientRect().height;
+    if (!naturalW || !naturalH) return;
+    const fit = Math.min(
+      viewport.offsetWidth / naturalW,
+      viewport.offsetHeight / naturalH,
+      1,
+    );
+    const scale = Math.max(fit * 0.95, 0.1);
+    api.centerView(scale, 0);
+  }, []);
+
+  // Fit on every re-render of the SVG markup (initial mount, theme
+  // swap, source toggle). The user's manual zoom/pan resets here on
+  // purpose — stale transforms would point at empty space after a
+  // re-render.
   useEffect(() => {
     if (!svg) return;
-    const raf = requestAnimationFrame(() => {
-      const api = transformApiRef.current;
-      const viewport = viewportRef.current;
-      const svgEl = containerRef.current?.querySelector('svg');
-      if (!api || !viewport || !svgEl) return;
-      const vb = svgEl.viewBox?.baseVal;
-      const naturalW = vb && vb.width
-        ? vb.width
-        : svgEl.getBoundingClientRect().width;
-      const naturalH = vb && vb.height
-        ? vb.height
-        : svgEl.getBoundingClientRect().height;
-      if (!naturalW || !naturalH) return;
-      // 0.95 leaves a little breathing room around the diagram so it
-      // doesn't kiss the viewport edges. Capped at 1.0 so a 2-node
-      // flowchart doesn't render with 80px text.
-      const fit = Math.min(
-        viewport.offsetWidth / naturalW,
-        viewport.offsetHeight / naturalH,
-        1,
-      );
-      const scale = Math.max(fit * 0.95, 0.1);
-      api.centerView(scale, 0);
-    });
+    const raf = requestAnimationFrame(fitToViewport);
     return () => cancelAnimationFrame(raf);
-  }, [svg]);
+  }, [svg, fitToViewport]);
 
   const handleDownload = () => {
     const svgData = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
@@ -663,7 +668,7 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
         >
           {() => (
             <>
-              <DiagramControls onDownload={handleDownload} />
+              <DiagramControls onDownload={handleDownload} onReset={fitToViewport} />
               <TransformComponent
                 wrapperStyle={{
                   width: '100%',

--- a/stash_ui/src/app/components/MermaidDiagram.tsx
+++ b/stash_ui/src/app/components/MermaidDiagram.tsx
@@ -446,10 +446,11 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
     api.centerView(scale, 0);
   }, []);
 
-  // Fit on every re-render of the SVG markup (initial mount, theme
-  // swap, source toggle). The user's manual zoom/pan resets here on
-  // purpose — stale transforms would point at empty space after a
-  // re-render.
+  // Fit on every re-render of the SVG markup (initial mount and
+  // theme swaps — toggling ``showSource`` doesn't touch ``svg`` so
+  // it doesn't re-trigger this effect). The user's manual zoom/pan
+  // resets here on purpose: stale transforms would point at empty
+  // space after a re-render.
   useEffect(() => {
     if (!svg) return;
     const raf = requestAnimationFrame(fitToViewport);

--- a/stash_ui/src/app/components/MetadataPanel.tsx
+++ b/stash_ui/src/app/components/MetadataPanel.tsx
@@ -91,6 +91,13 @@ export function MetadataPanel({
   };
 
   const getMimeType = () => {
+    // Prefer an explicit ``mimeType`` from the API / selection layer
+    // when available — binary files (image/PDF) populate it from the
+    // file extension because the JSON content fetch is skipped for
+    // them, and the server returns it for text files via the content
+    // endpoint. Fall back to a tiny ext→mime map for the legacy
+    // text cases.
+    if (file.mimeType) return file.mimeType;
     const ext = file.extension;
     if (ext === 'md') return 'text/markdown';
     if (ext === 'json') return 'application/json';
@@ -316,7 +323,7 @@ export function MetadataPanel({
                 File Size
               </div>
               <div className="text-sm" style={{ color: 'var(--stash-text-primary)' }}>
-                {formatFileSize(file.size || 0)}
+                {file.size !== undefined ? formatFileSize(file.size) : '—'}
               </div>
             </div>
 
@@ -334,7 +341,7 @@ export function MetadataPanel({
                 Last Modified
               </div>
               <div className="text-sm" style={{ color: 'var(--stash-text-primary)' }}>
-                {file.lastModified ? formatDate(file.lastModified) : 'Unknown'}
+                {file.lastModified ? formatDate(file.lastModified) : '—'}
               </div>
             </div>
 

--- a/stash_ui/src/app/components/OpenApiViewer.tsx
+++ b/stash_ui/src/app/components/OpenApiViewer.tsx
@@ -563,10 +563,10 @@ export function OpenApiViewer({ spec, onEndpointsChange, onActiveEndpointChange 
                 )}
                 <div className="flex items-center gap-2">
                   {apiSpec.info?.version && (
-                    <span 
+                    <span
                       className="px-3 py-1 rounded text-sm font-mono"
-                      style={{ 
-                        backgroundColor: 'rgba(148, 226, 213, 0.2)',
+                      style={{
+                        backgroundColor: 'color-mix(in srgb, var(--stash-accent) 20%, transparent)',
                         color: 'var(--stash-accent)'
                       }}
                     >

--- a/stash_ui/src/app/pages/DocumentsPage.tsx
+++ b/stash_ui/src/app/pages/DocumentsPage.tsx
@@ -5,7 +5,7 @@ import { ConcurrentEditError } from '../../api/fetch';
 import { useStore } from '../StoreContext';
 import { FileTree } from '../components/FileTree';
 import { DocumentViewer } from '../components/DocumentViewer';
-import { classifyBinary } from '../components/BinaryFileViewer';
+import { classifyBinary, mimeTypeForBinary } from '../components/BinaryFileViewer';
 import { DirectoryListing } from '../components/DirectoryListing';
 import { MetadataPanel } from '../components/MetadataPanel';
 import { OverviewContent } from '../components/OverviewContent';
@@ -142,10 +142,19 @@ export function DocumentsPage() {
     // Images and PDFs are streamed by the raw-bytes endpoint and don't
     // need text content — skip the JSON fetch so we don't 415. HTML
     // still goes through getContent so it can be previewed and edited.
+    // Populate mimeType from the extension so the metadata panel
+    // shows e.g. ``image/png`` instead of falling back to
+    // ``text/plain``. ``size`` and ``lastModified`` stay undefined —
+    // the panel renders ``—`` for those rather than misleading
+    // zeros (we don't fetch metadata to avoid an extra round-trip).
     const binaryKind = classifyBinary(file.extension);
     if (binaryKind === 'image' || binaryKind === 'pdf') {
       latestSelectionRef.current += 1;
-      setSelectedFile({ ...file, content: '' });
+      setSelectedFile({
+        ...file,
+        content: '',
+        mimeType: mimeTypeForBinary(file.extension),
+      });
       setSelectedEtag(null);
       setIsContentLoading(false);
       return;

--- a/stash_ui/src/app/pages/DocumentsPage.tsx
+++ b/stash_ui/src/app/pages/DocumentsPage.tsx
@@ -5,6 +5,7 @@ import { ConcurrentEditError } from '../../api/fetch';
 import { useStore } from '../StoreContext';
 import { FileTree } from '../components/FileTree';
 import { DocumentViewer } from '../components/DocumentViewer';
+import { classifyBinary } from '../components/BinaryFileViewer';
 import { DirectoryListing } from '../components/DirectoryListing';
 import { MetadataPanel } from '../components/MetadataPanel';
 import { OverviewContent } from '../components/OverviewContent';
@@ -134,6 +135,18 @@ export function DocumentsPage() {
       setSelectedEtag(file.etag);
       // Same reason as the folder branch — clear in case an earlier
       // uncached load set the spinner and is now invalidated.
+      setIsContentLoading(false);
+      return;
+    }
+
+    // Images and PDFs are streamed by the raw-bytes endpoint and don't
+    // need text content — skip the JSON fetch so we don't 415. HTML
+    // still goes through getContent so it can be previewed and edited.
+    const binaryKind = classifyBinary(file.extension);
+    if (binaryKind === 'image' || binaryKind === 'pdf') {
+      latestSelectionRef.current += 1;
+      setSelectedFile({ ...file, content: '' });
+      setSelectedEtag(null);
       setIsContentLoading(false);
       return;
     }
@@ -599,6 +612,7 @@ export function DocumentsPage() {
               onSectionsChange={setSections}
               onActiveSectionChange={setActiveSectionId}
               onSectionsTitleChange={setSectionsTitle}
+              rawUrl={client ? (path) => client.rawUrl(path) : undefined}
             />
           )}
         </Panel>

--- a/stash_ui/src/styles/theme.css
+++ b/stash_ui/src/styles/theme.css
@@ -13,6 +13,12 @@
   --stash-accent: #94e2d5;
   --stash-destructive: #f38ba8;
   --stash-border: #313244;
+  /* Auxiliary text — one step further from the foreground than
+   * ``text-secondary``. Used for badge labels, counts, and metadata
+   * across the spec viewers. Derived from the active theme so it
+   * tracks ``applyTheme()`` swaps (which only touch the explicit
+   * variables above). */
+  --stash-text-muted: color-mix(in srgb, var(--stash-text-secondary) 65%, var(--stash-bg-base));
 }
 
 .dark {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,6 +418,17 @@ def test_content_endpoint_415_for_binary():
         assert "raw" in response.json()["detail"]
 
 
+def test_content_endpoint_404_for_missing_binary():
+    """Missing binary file should 404 — the binary-type guard must not
+    short-circuit existence checks."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        client = TestClient(create_api(fs))
+
+        response = client.get("/api/content/missing.png")
+        assert response.status_code == 404
+
+
 def test_raw_endpoint_304_on_if_none_match():
     with TemporaryDirectory() as tmpdir:
         fs = FileSystem(Path(tmpdir))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -439,3 +439,81 @@ def test_raw_endpoint_304_on_if_none_match():
         etag = first.headers["etag"]
         cached = client.get("/api/raw/logo.png", headers={"If-None-Match": etag})
         assert cached.status_code == 304
+
+
+def test_raw_endpoint_sets_sandbox_csp():
+    """Every raw response must carry ``Content-Security-Policy: sandbox``
+    so scriptable artifacts (.html/.svg) opened directly run in an
+    opaque origin without access to the Stash session/API. Also locks
+    in ``X-Content-Type-Options: nosniff``."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        (Path(tmpdir) / "logo.png").write_bytes(_PNG_BYTES)
+        client = TestClient(create_api(fs))
+
+        response = client.get("/api/raw/logo.png")
+        assert response.status_code == 200
+        assert response.headers.get("content-security-policy") == "sandbox"
+        assert response.headers.get("x-content-type-options") == "nosniff"
+
+        # The 304 path applies the same policy so cached responses
+        # don't drop the sandbox.
+        cached = client.get(
+            "/api/raw/logo.png",
+            headers={"If-None-Match": response.headers["etag"]},
+        )
+        assert cached.status_code == 304
+        assert cached.headers.get("content-security-policy") == "sandbox"
+
+
+def test_content_endpoint_400_for_directory():
+    """``GET /api/content/<dir>`` must surface a 400 — falling through
+    to 404 would hide the real problem (path resolves to a directory)
+    from the client."""
+    with TemporaryDirectory() as tmpdir:
+        (Path(tmpdir) / "docs").mkdir()
+        fs = FileSystem(Path(tmpdir))
+        client = TestClient(create_api(fs))
+
+        response = client.get("/api/content/docs")
+        assert response.status_code == 400
+        assert "not a file" in response.json()["detail"].lower()
+
+
+def test_content_endpoint_415_for_non_utf8_text_file():
+    """A file without a known binary extension that contains non-UTF-8
+    bytes must 415 (with a raw-bytes hint), not 500. Locks in the
+    ``UnicodeDecodeError`` re-raise in ``FileSystem.read_file``."""
+    with TemporaryDirectory() as tmpdir:
+        # Latin-1 bytes that are invalid UTF-8.
+        (Path(tmpdir) / "notes.dat").write_bytes(b"caf\xe9 noir")
+        fs = FileSystem(Path(tmpdir))
+        client = TestClient(create_api(fs))
+
+        response = client.get("/api/content/notes.dat")
+        assert response.status_code == 415
+        assert "raw" in response.json()["detail"].lower()
+
+
+def test_content_endpoint_415_hint_preserves_request_prefix():
+    """The 415 ``detail`` must build the raw URL from the caller's
+    request path so tenant/store-scoped deployments get a usable hint
+    instead of a hard-coded ``/api/raw/...`` that would 404 in their
+    routing."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        (Path(tmpdir) / "logo.png").write_bytes(_PNG_BYTES)
+        app = create_api(fs)
+
+        # Mount the API under a scoped prefix to simulate the
+        # tenant/store layout (`/api/<tenant>/<store>/content/...`).
+        from fastapi import FastAPI
+
+        outer = FastAPI()
+        outer.mount("/api/acme/main", app)
+        client = TestClient(outer)
+
+        response = client.get("/api/acme/main/api/content/logo.png")
+        assert response.status_code == 415
+        detail = response.json()["detail"]
+        assert "/api/acme/main/api/raw/logo.png" in detail

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -496,24 +496,130 @@ def test_content_endpoint_415_for_non_utf8_text_file():
 
 
 def test_content_endpoint_415_hint_preserves_request_prefix():
-    """The 415 ``detail`` must build the raw URL from the caller's
-    request path so tenant/store-scoped deployments get a usable hint
-    instead of a hard-coded ``/api/raw/...`` that would 404 in their
-    routing."""
+    """The 415 ``detail`` must build the raw URL from the path
+    ``StoreResolverMiddleware`` stashes in
+    ``scope["stash.original_path"]``, so tenant/store-scoped
+    deployments get a usable
+    ``/api/<tenant>/<store>/raw/<path>`` hint instead of a
+    hard-coded ``/api/raw/<path>`` that would 404 in their routing.
+
+    Wraps the API in a minimal ASGI shim that mirrors what
+    ``StoreResolverMiddleware`` does in production: rewrite
+    ``/api/<tenant>/<store>/content/foo`` to ``/api/content/foo`` on
+    the inner scope, and remember the original on
+    ``scope["stash.original_path"]``. The earlier ``app.mount()``
+    version of this test passed even before the scope key existed
+    because ``mount()`` happens to leave the prefix in
+    ``request.url.path`` — production does not.
+    """
+
+    class _PrefixRewrite:
+        def __init__(self, app, public_prefix: str) -> None:
+            self.app = app
+            self.public_prefix = public_prefix
+
+        async def __call__(self, scope, receive, send):
+            if scope["type"] == "http" and scope["path"].startswith(self.public_prefix):
+                original_path = scope["path"]
+                rewritten = original_path[len(self.public_prefix):] or "/"
+                new_scope = dict(scope)
+                new_scope["path"] = rewritten
+                new_scope["raw_path"] = rewritten.encode("utf-8")
+                new_scope["stash.original_path"] = original_path
+                await self.app(new_scope, receive, send)
+                return
+            await self.app(scope, receive, send)
+
     with TemporaryDirectory() as tmpdir:
         fs = FileSystem(Path(tmpdir))
         (Path(tmpdir) / "logo.png").write_bytes(_PNG_BYTES)
-        app = create_api(fs)
-
-        # Mount the API under a scoped prefix to simulate the
-        # tenant/store layout (`/api/<tenant>/<store>/content/...`).
-        from fastapi import FastAPI
-
-        outer = FastAPI()
-        outer.mount("/api/acme/main", app)
-        client = TestClient(outer)
+        # `/api/acme/main` is the stripped prefix; the inner API still
+        # sees `/api/content/logo.png`.
+        wrapped = _PrefixRewrite(create_api(fs), public_prefix="/api/acme/main")
+        client = TestClient(wrapped)
 
         response = client.get("/api/acme/main/api/content/logo.png")
         assert response.status_code == 415
         detail = response.json()["detail"]
+        assert "/api/acme/main/api/content/logo.png" not in detail
         assert "/api/acme/main/api/raw/logo.png" in detail
+
+
+def test_store_resolver_middleware_stashes_original_path():
+    """``StoreResolverMiddleware`` must hand the inner app the
+    original client-facing path on ``scope["stash.original_path"]``
+    so handlers can build user-facing hints. Tested directly against
+    the middleware to keep the test honest about what production
+    actually does."""
+    from stash_mcp.routing.store_resolver import StoreResolverMiddleware
+
+    captured: dict = {}
+
+    async def inner(scope, receive, send):
+        captured["path"] = scope["path"]
+        captured["original_path"] = scope.get("stash.original_path")
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    middleware = StoreResolverMiddleware(inner, registry=None, public_prefixes=())
+    # Force AUTH_ENABLED so the rewrite path runs. Falling back to the
+    # passthrough branch would skip the scope mutation entirely.
+    from stash_mcp.config import Config
+
+    previous_auth = Config.AUTH_ENABLED
+    Config.AUTH_ENABLED = True
+
+    class _FakeStore:
+        tenant_id = "tid"
+        tenant_slug = "acme"
+        slug = "main"
+
+    class _FakeRegistry:
+        async def get(self, tenant, store):  # noqa: D401
+            return _FakeStore()
+
+    middleware.registry = _FakeRegistry()
+
+    # Stub a principal that is a member of the resolved tenant_id so
+    # the middleware proceeds to the rewrite branch instead of 403ing.
+    from stash_mcp.auth.context import (
+        reset_current_principal,
+        set_current_principal,
+    )
+
+    class _StubPrincipal:
+        def has_role_on(self, tenant_id, role):  # noqa: D401
+            return True
+
+    token = set_current_principal(_StubPrincipal())
+    try:
+        async def _run() -> None:
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/api/acme/main/content/foo.png",
+                "raw_path": b"/api/acme/main/content/foo.png",
+                "headers": [],
+            }
+
+            async def receive():
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            sent: list = []
+
+            async def send(message):
+                sent.append(message)
+
+            await middleware(scope, receive, send)
+
+        import asyncio
+
+        asyncio.run(_run())
+    finally:
+        reset_current_principal(token)
+        Config.AUTH_ENABLED = previous_auth
+
+    # Rewritten path (what the FastAPI app sees) drops the
+    # tenant/store; original path (for hint-building) keeps it.
+    assert captured["path"] == "/api/content/foo.png"
+    assert captured["original_path"] == "/api/acme/main/content/foo.png"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -370,3 +370,61 @@ def test_event_emitted_on_patch_move(test_client, event_listener):
     assert args[0] == "content_moved"
     assert args[1] == "moved.md"
     assert kwargs.get("source_path") == "test.md"
+
+
+# --- Raw bytes endpoint tests ---
+
+
+# 1x1 transparent PNG.
+_PNG_BYTES = bytes.fromhex(
+    "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C489"
+    "0000000D49444154789C636000000000050001E221BC330000000049454E44AE426082"
+)
+
+
+def test_raw_endpoint_streams_image_bytes():
+    """The raw endpoint returns binary file contents with the right
+    Content-Type, leaving them untouched by UTF-8 decoding."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        (Path(tmpdir) / "logo.png").write_bytes(_PNG_BYTES)
+        client = TestClient(create_api(fs))
+
+        response = client.get("/api/raw/logo.png")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("image/png")
+        assert response.content == _PNG_BYTES
+        assert response.headers.get("etag") is not None
+
+
+def test_raw_endpoint_404_on_missing():
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        client = TestClient(create_api(fs))
+        response = client.get("/api/raw/missing.png")
+        assert response.status_code == 404
+
+
+def test_content_endpoint_415_for_binary():
+    """GET /api/content/{path} surfaces 415 for known-binary types so
+    callers know to use the raw endpoint instead."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        (Path(tmpdir) / "logo.png").write_bytes(_PNG_BYTES)
+        client = TestClient(create_api(fs))
+
+        response = client.get("/api/content/logo.png")
+        assert response.status_code == 415
+        assert "raw" in response.json()["detail"]
+
+
+def test_raw_endpoint_304_on_if_none_match():
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        (Path(tmpdir) / "logo.png").write_bytes(_PNG_BYTES)
+        client = TestClient(create_api(fs))
+
+        first = client.get("/api/raw/logo.png")
+        etag = first.headers["etag"]
+        cached = client.get("/api/raw/logo.png", headers={"If-None-Match": etag})
+        assert cached.status_code == 304


### PR DESCRIPTION
## Summary

Adds support for rendering binary files (images, PDFs, HTML) directly in the document viewer. Images and PDFs stream from a new `/api/raw/{path}` endpoint that serves raw bytes with proper `Content-Type` headers. HTML artifacts render in a sandboxed iframe to safely execute scripts without access to the parent origin's cookies or APIs.

## Key Changes

**Backend (`stash_mcp/`)**
- New `/api/raw/{path}` endpoint streams binary file bytes with correct MIME types and ETag support for browser caching
- `/api/content/{path}` now returns 415 Unsupported Media Type for known-binary extensions (images, PDFs), directing clients to use the raw endpoint instead
- Added `BINARY_EXTENSIONS` constant to `mcp_server.py` defining which file types cannot be decoded as UTF-8 text
- Added `_is_binary_path()` helper to classify files by extension
- Added `UnicodeDecodeError` handling in content endpoint to catch non-UTF-8 files

**Frontend (`stash_ui/`)**
- New `BinaryFileViewer` component renders images, PDFs, and HTML with appropriate UI:
  - **Images**: Centered with shadow, responsive scaling via `object-fit: contain`
  - **PDFs**: Embedded iframe with native browser PDF viewer
  - **HTML**: Sandboxed iframe with `allow-scripts` but no `allow-same-origin` (null origin isolation)
- `classifyBinary()` utility function determines file type from extension
- `HtmlSandboxFrame` uses blob URLs instead of `srcDoc` to avoid length caps and re-render issues with large artifacts
- `DocumentViewer` now detects binary files and renders them directly in view mode; HTML files remain editable
- New `rawUrl` prop on `DocumentViewer` provides the URL builder for raw bytes
- `DocumentsPage` skips JSON content fetch for images/PDFs (would 415) but still fetches HTML for preview/edit
- New `rawUrl()` function in API client builds properly encoded URLs for raw file access
- `ApiClient` interface includes `rawUrl` method

**Tests (`tests/test_api.py`)**
- Added tests for raw endpoint: binary streaming, 404 handling, ETag caching (304 Not Modified)
- Added test verifying `/api/content/{path}` returns 415 for binary files with helpful error message

## Implementation Details

- **Security**: HTML artifacts run in a null-origin sandbox (`sandbox="allow-scripts allow-forms allow-popups allow-modals"` without `allow-same-origin`), preventing access to parent cookies and APIs
- **Performance**: Raw endpoint honors `If-None-Match` headers for aggressive browser caching; blob URLs for HTML avoid re-renders on editor changes
- **UX**: Binary files show view/edit tabs; only HTML is editable (images/PDFs are read-only)
- **Compatibility**: Falls back gracefully when `rawUrl` is not provided; binary detection is extension-based for simplicity

https://claude.ai/code/session_01CY6ThM4SAUQg4pNKPw6o3V