### PR TITLE
Add SVG file support with live preview and editable source

### DIFF
--- a/stash_ui/src/app/components/BinaryFileViewer.tsx
+++ b/stash_ui/src/app/components/BinaryFileViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
-export type BinaryKind = 'image' | 'pdf' | 'html';
+export type BinaryKind = 'image' | 'pdf' | 'html' | 'svg';
 
 const IMAGE_EXTS = new Set([
-  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico', 'bmp', 'avif',
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp', 'avif',
 ]);
 
 /** Map extension → MIME type for the file kinds the binary viewer
@@ -31,14 +31,18 @@ export function mimeTypeForBinary(extension: string | undefined): string | undef
   return BINARY_MIME_BY_EXT[extension.toLowerCase()];
 }
 
-/** Classify a file as image / pdf / html / null based on extension.
+/** Classify a file as image / pdf / html / svg / null based on extension.
  *
- * SVG renders inline as an image rather than via an HTML iframe so the
- * file's `<script>` tags (if any) don't execute against the same origin
- * as the rest of the app. */
+ * SVG is split out from raster images because it round-trips through
+ * the JSON content endpoint as text — that lets the viewer render the
+ * in-memory document (so unsaved edits preview live) and lets the
+ * caller swap into an edit textarea. The rendered preview still goes
+ * through an `<img>` element with a blob URL so any embedded
+ * `<script>` tags stay inert. */
 export function classifyBinary(extension: string | undefined): BinaryKind | null {
   if (!extension) return null;
   const ext = extension.toLowerCase();
+  if (ext === 'svg') return 'svg';
   if (IMAGE_EXTS.has(ext)) return 'image';
   if (ext === 'pdf') return 'pdf';
   if (ext === 'html' || ext === 'htm') return 'html';
@@ -57,6 +61,10 @@ interface BinaryFileViewerProps {
    * sandboxed iframe so it can't reach the parent origin's cookies or
    * APIs. */
   htmlContent?: string;
+  /** Inline SVG text (for `kind === 'svg'`). Rendered via a blob URL
+   * in an `<img>` element so unsaved edits preview live without
+   * letting the SVG's `<script>` tags run against the parent origin. */
+  svgContent?: string;
   fileName: string;
 }
 
@@ -66,7 +74,10 @@ interface BinaryFileViewerProps {
  * iframe with a strict ``sandbox`` so the artifact runs in a null
  * origin — blob URLs replace the legacy ``srcDoc`` approach to avoid
  * its length cap and per-keystroke re-render. */
-export function BinaryFileViewer({ kind, rawUrl, htmlContent, fileName }: BinaryFileViewerProps) {
+export function BinaryFileViewer({ kind, rawUrl, htmlContent, svgContent, fileName }: BinaryFileViewerProps) {
+  if (kind === 'svg') {
+    return <SvgPreview content={svgContent ?? ''} rawUrl={rawUrl} fileName={fileName} />;
+  }
   if (kind === 'image') {
     if (!rawUrl) return <UnavailableState reason="image" />;
     return (
@@ -134,6 +145,53 @@ function UnavailableState({ reason }: { reason: 'image' | 'pdf' }) {
           The API client cannot construct a raw URL for this file.
         </div>
       </div>
+    </div>
+  );
+}
+
+function SvgPreview({
+  content,
+  rawUrl,
+  fileName,
+}: {
+  content: string;
+  rawUrl?: string;
+  fileName: string;
+}) {
+  // Prefer rendering from the in-memory document so unsaved edits
+  // preview live. Fall back to the raw URL only when the editor
+  // hasn't yet provided content (e.g. file is still loading).
+  const [src, setSrc] = useState<string | null>(null);
+  useEffect(() => {
+    if (!content) {
+      setSrc(null);
+      return;
+    }
+    const blob = new Blob([content], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    setSrc(url);
+    return () => URL.revokeObjectURL(url);
+  }, [content]);
+
+  const imgSrc = src ?? rawUrl;
+  if (!imgSrc) return <UnavailableState reason="image" />;
+
+  return (
+    <div
+      className="h-full w-full flex items-center justify-center overflow-auto p-8"
+      style={{ backgroundColor: 'var(--stash-bg-base)' }}
+    >
+      <img
+        src={imgSrc}
+        alt={fileName}
+        style={{
+          maxWidth: '100%',
+          maxHeight: '100%',
+          objectFit: 'contain',
+          boxShadow: '0 4px 24px rgba(0, 0, 0, 0.4)',
+          backgroundColor: 'var(--stash-bg-surface)',
+        }}
+      />
     </div>
   );
 }

--- a/stash_ui/src/app/components/BinaryFileViewer.tsx
+++ b/stash_ui/src/app/components/BinaryFileViewer.tsx
@@ -68,12 +68,15 @@ interface BinaryFileViewerProps {
   fileName: string;
 }
 
-/** Renders images, PDFs, and HTML artifacts inside the document
- * viewport. Images and PDFs stream from the API's raw endpoint;
- * HTML is wrapped in a same-document blob URL and loaded into an
- * iframe with a strict ``sandbox`` so the artifact runs in a null
- * origin — blob URLs replace the legacy ``srcDoc`` approach to avoid
- * its length cap and per-keystroke re-render. */
+/** Renders images, PDFs, SVGs, and HTML artifacts inside the
+ * document viewport. Images and PDFs stream from the API's raw
+ * endpoint; HTML is wrapped in a same-document blob URL and loaded
+ * into an iframe with a strict ``sandbox`` so the artifact runs in a
+ * null origin — blob URLs replace the legacy ``srcDoc`` approach to
+ * avoid its length cap and per-keystroke re-render. SVG is rendered
+ * via an ``<img>`` element pointing at a blob URL built from the
+ * in-memory document, which keeps any embedded ``<script>`` tags
+ * inert and lets unsaved edits preview live. */
 export function BinaryFileViewer({ kind, rawUrl, htmlContent, svgContent, fileName }: BinaryFileViewerProps) {
   if (kind === 'svg') {
     return <SvgPreview content={svgContent ?? ''} rawUrl={rawUrl} fileName={fileName} />;

--- a/stash_ui/src/app/components/DocumentViewer.tsx
+++ b/stash_ui/src/app/components/DocumentViewer.tsx
@@ -381,16 +381,127 @@ export function DocumentViewer({
     );
   }
 
-  // Images and PDFs can't round-trip through the JSON content endpoint,
-  // so view mode renders them directly from the raw bytes URL. HTML
-  // and SVG artifacts are text — they render in a preview pane but
-  // keep their source editable in a textarea.
-  const isEditable = binaryKind === 'html' || binaryKind === 'svg';
+  // SVG documents have their own branch so edit mode can render a
+  // live preview alongside the source textarea — unlike HTML (where
+  // an iframe re-render on every keystroke would be costly), an
+  // `<img>`-backed SVG preview cheaply reflects each edit.
+  if (binaryKind === 'svg') {
+    const previewContent = mode === 'edit' ? editContent : (file.content || '');
+    return (
+      <div className="h-full flex flex-col" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
+        <div className="flex items-center border-b" style={{ borderColor: 'var(--stash-border)' }}>
+          <button
+            onClick={() => setMode('view')}
+            className="flex items-center gap-2 px-6 py-3 transition-all duration-150 relative"
+            style={{
+              color: mode === 'view' ? 'var(--stash-text-bright)' : 'var(--stash-text-secondary)',
+              borderBottom: mode === 'view' ? '2px solid var(--stash-accent)' : '2px solid transparent',
+            }}
+          >
+            <Eye className="w-4 h-4" />
+            <span className="text-sm">SVG Preview</span>
+          </button>
+          <button
+            onClick={() => setMode('edit')}
+            className="flex items-center gap-2 px-6 py-3 transition-all duration-150 relative"
+            style={{
+              color: mode === 'edit' ? 'var(--stash-text-bright)' : 'var(--stash-text-secondary)',
+              borderBottom: mode === 'edit' ? '2px solid var(--stash-accent)' : '2px solid transparent',
+            }}
+          >
+            <Edit className="w-4 h-4" />
+            <span className="text-sm">Edit</span>
+            {hasChanges && (
+              <div
+                className="w-2 h-2 rounded-full"
+                style={{ backgroundColor: 'var(--stash-accent)' }}
+              />
+            )}
+          </button>
+        </div>
+        <div className="flex-1 overflow-hidden">
+          {mode === 'view' ? (
+            <BinaryFileViewer
+              kind="svg"
+              rawUrl={rawUrl ? rawUrl(file.path) : undefined}
+              svgContent={previewContent}
+              fileName={file.name}
+            />
+          ) : (
+            <div className="h-full flex" style={{ borderColor: 'var(--stash-border)' }}>
+              <div
+                className="flex-1 overflow-auto p-4"
+                style={{ borderRight: '1px solid var(--stash-border)' }}
+              >
+                <textarea
+                  value={editContent}
+                  onChange={(e) => handleContentChange(e.target.value)}
+                  className="w-full h-full p-4 rounded-md font-mono text-sm resize-none outline-none"
+                  style={{
+                    backgroundColor: 'var(--stash-bg-surface)',
+                    color: 'var(--stash-text-primary)',
+                    border: '1px solid var(--stash-border)',
+                    lineHeight: '1.6',
+                    minHeight: '600px',
+                  }}
+                />
+              </div>
+              <div className="flex-1 overflow-hidden">
+                <BinaryFileViewer
+                  kind="svg"
+                  rawUrl={rawUrl ? rawUrl(file.path) : undefined}
+                  svgContent={previewContent}
+                  fileName={file.name}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        {hasChanges && mode === 'edit' && (
+          <div
+            className="sticky bottom-0 flex items-center justify-center gap-3 px-8 py-4 backdrop-blur-md"
+            style={{
+              backgroundColor: 'rgba(30, 30, 46, 0.95)',
+              borderTop: '1px solid var(--stash-border)',
+            }}
+          >
+            <button
+              onClick={handleSave}
+              className="flex items-center gap-2 px-6 py-2 rounded-md transition-all duration-150"
+              style={{
+                backgroundColor: 'var(--stash-accent)',
+                color: 'var(--stash-bg-base)',
+              }}
+            >
+              <Save className="w-4 h-4" />
+              <span className="text-sm">Save</span>
+            </button>
+            <button
+              onClick={handleDiscard}
+              className="flex items-center gap-2 px-6 py-2 rounded-md transition-all duration-150"
+              style={{
+                backgroundColor: 'transparent',
+                color: 'var(--stash-text-secondary)',
+                border: '1px solid var(--stash-border)',
+              }}
+            >
+              <X className="w-4 h-4" />
+              <span className="text-sm">Discard</span>
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Images, PDFs, and HTML round trip through the binary viewer. HTML
+  // is editable via a fall-through to the textarea below; images and
+  // PDFs are view-only.
+  const isEditable = binaryKind === 'html';
   if (binaryKind !== null && (mode === 'view' || !isEditable)) {
     const previewLabel =
       binaryKind === 'image' ? 'Image'
         : binaryKind === 'pdf' ? 'PDF'
-        : binaryKind === 'svg' ? 'SVG Preview'
         : 'HTML Preview';
     return (
       <div className="h-full flex flex-col" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
@@ -431,7 +542,6 @@ export function DocumentViewer({
             kind={binaryKind}
             rawUrl={rawUrl ? rawUrl(file.path) : undefined}
             htmlContent={file.content || ''}
-            svgContent={file.content || ''}
             fileName={file.name}
           />
         </div>

--- a/stash_ui/src/app/components/DocumentViewer.tsx
+++ b/stash_ui/src/app/components/DocumentViewer.tsx
@@ -334,13 +334,12 @@ export function DocumentViewer({
   const isComponentContract = isComponentContractSpec();
   const isArazzo = isArazzoSpec();
   const binaryKind = classifyBinary(file.extension);
+  const isMermaidFile =
+    file.extension === 'mmd' || file.extension === 'mermaid';
 
-  // Images and PDFs can't round-trip through the JSON content endpoint,
-  // so view mode renders them directly from the raw bytes URL. HTML
-  // artifacts render in a sandboxed iframe but keep their text content
-  // editable.
-  const isEditable = binaryKind === 'html';
-  if (binaryKind !== null && (mode === 'view' || !isEditable)) {
+  // Standalone Mermaid documents render as a diagram in view mode and
+  // fall back to the text editor when the user switches to edit.
+  if (isMermaidFile && mode === 'view') {
     return (
       <div className="h-full flex flex-col" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
         <div className="flex items-center border-b" style={{ borderColor: 'var(--stash-border)' }}>
@@ -353,11 +352,59 @@ export function DocumentViewer({
             }}
           >
             <Eye className="w-4 h-4" />
-            <span className="text-sm">
-              {binaryKind === 'image' ? 'Image'
-                : binaryKind === 'pdf' ? 'PDF'
-                : 'HTML Preview'}
-            </span>
+            <span className="text-sm">Diagram</span>
+          </button>
+          <button
+            onClick={() => setMode('edit')}
+            className="flex items-center gap-2 px-6 py-3 transition-all duration-150 relative"
+            style={{
+              color: 'var(--stash-text-secondary)',
+              borderBottom: '2px solid transparent',
+            }}
+          >
+            <Edit className="w-4 h-4" />
+            <span className="text-sm">Edit</span>
+            {hasChanges && (
+              <div
+                className="w-2 h-2 rounded-full"
+                style={{ backgroundColor: 'var(--stash-accent)' }}
+              />
+            )}
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-[900px] mx-auto px-8 py-8">
+            <MermaidDiagram chart={file.content || ''} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Images and PDFs can't round-trip through the JSON content endpoint,
+  // so view mode renders them directly from the raw bytes URL. HTML
+  // and SVG artifacts are text — they render in a preview pane but
+  // keep their source editable in a textarea.
+  const isEditable = binaryKind === 'html' || binaryKind === 'svg';
+  if (binaryKind !== null && (mode === 'view' || !isEditable)) {
+    const previewLabel =
+      binaryKind === 'image' ? 'Image'
+        : binaryKind === 'pdf' ? 'PDF'
+        : binaryKind === 'svg' ? 'SVG Preview'
+        : 'HTML Preview';
+    return (
+      <div className="h-full flex flex-col" style={{ backgroundColor: 'var(--stash-bg-base)' }}>
+        <div className="flex items-center border-b" style={{ borderColor: 'var(--stash-border)' }}>
+          <button
+            onClick={() => setMode('view')}
+            className="flex items-center gap-2 px-6 py-3 transition-all duration-150 relative"
+            style={{
+              color: 'var(--stash-text-bright)',
+              borderBottom: '2px solid var(--stash-accent)',
+            }}
+          >
+            <Eye className="w-4 h-4" />
+            <span className="text-sm">{previewLabel}</span>
           </button>
           {isEditable && (
             <button
@@ -384,6 +431,7 @@ export function DocumentViewer({
             kind={binaryKind}
             rawUrl={rawUrl ? rawUrl(file.path) : undefined}
             htmlContent={file.content || ''}
+            svgContent={file.content || ''}
             fileName={file.name}
           />
         </div>


### PR DESCRIPTION
## Summary

Adds first-class support for SVG files in the document viewer. SVG files now render as editable text documents with a live preview pane, similar to HTML artifacts. This allows users to view and edit SVG source code with real-time preview updates while keeping embedded scripts inert via blob URL rendering.

## Key Changes

- **BinaryFileViewer component**:
  - Added `'svg'` to `BinaryKind` type
  - Removed `'svg'` from `IMAGE_EXTS` set to treat SVG as a distinct file type
  - Updated `classifyBinary()` to return `'svg'` kind for `.svg` files
  - Added new `SvgPreview` component that renders SVG content via blob URL in an `<img>` element
  - Added `svgContent` prop to `BinaryFileViewerProps` for passing in-memory SVG text
  - Updated JSDoc to explain SVG handling: content round-trips through JSON endpoint as text, enabling live preview of unsaved edits while keeping `<script>` tags inert

- **DocumentViewer component**:
  - Added Mermaid diagram support: standalone `.mmd`/`.mermaid` files render as diagrams in view mode with a "Diagram" / "Edit" tab switcher
  - Updated `isEditable` logic to include SVG files alongside HTML (both are text-based and support live editing)
  - Added dynamic `previewLabel` that shows "SVG Preview" for SVG files
  - Passed `svgContent` prop to `BinaryFileViewer` for SVG rendering

## Implementation Details

The `SvgPreview` component uses a `useEffect` hook to create a blob URL from the SVG content string. This approach:
- Prioritizes in-memory content (for live preview of unsaved edits)
- Falls back to the raw URL only when content is unavailable (e.g., during initial load)
- Properly cleans up blob URLs on unmount or content change
- Renders via `<img>` with a blob URL to prevent embedded scripts from executing against the parent origin

SVG is now treated as an editable text format (like HTML) rather than a binary image, enabling the same split-pane editor + preview workflow.

https://claude.ai/code/session_012LisTYzYwB5qJDQ4yENxrX