### PR TITLE
Fix stash-mcp-usage skill: transactions are required for every write

### DIFF
--- a/skills/stash-mcp/skills/stash-mcp-usage/SKILL.md
+++ b/skills/stash-mcp/skills/stash-mcp-usage/SKILL.md
@@ -23,7 +23,7 @@ Think of Stash-MCP as a filesystem with guardrails:
 
 - **Files on disk** — markdown, code, any text format
 - **SHA-256 concurrency** — every read returns a hash; every write requires it. If the hash doesn't match, someone changed the file since you read it. Re-read, reassess, retry.
-- **Transactions** — optional global write lock for atomic multi-file changes. One transaction at a time across all sessions.
+- **Transactions** — when git tracking is enabled, *every* write requires an active transaction. The lock is global; one transaction at a time across all sessions.
 - **Semantic search** — natural language queries against embedded content chunks. Not keyword search.
 
 ## Tool Categories at a Glance
@@ -64,18 +64,20 @@ read_content(path)                  → read only what you actually need
 
 Use `overwrite_content` only when regenerating an entire file from scratch.
 
-### 3. Transactions for Multi-File Changes
+### 3. Transactions Wrap Every Write (when git tracking is on)
 
-Any operation touching more than one file should use a transaction:
+When the server has git tracking enabled, every write tool — even a single `create_content` or `edit_content` — requires an active transaction owned by your session. Calling a write tool without one raises `TransactionError: No active transaction`. The choreography is the same whether you're touching one file or twenty:
 
 ```
 list_content_transactions()    → check for orphans first
 start_content_transaction()    → acquire the global lock
-[... create, edit, delete, move operations ...]
+[... one or more create, edit, delete, move operations ...]
 commit_content_transaction(message="descriptive commit message")
 ```
 
-If something goes wrong mid-transaction, call `abort_content_transaction()` to roll back all changes. Without transactions, a failure mid-way leaves the store in an inconsistent state.
+Multi-file changes are simply the case where the transaction spans more than one operation — same mechanism, same atomicity guarantee. If something goes wrong mid-transaction, call `abort_content_transaction()` to roll back all staged changes.
+
+When git tracking is **off**, writes go straight to disk and the transaction tools aren't registered. Check the tool list to know which mode you're in.
 
 ### 4. SHA Means "I've Seen This Version"
 
@@ -98,7 +100,7 @@ See `references/search-strategy.md` for detailed guidance.
 
 - **Reading entire files when you only need structure** — use `inspect_content_structure`
 - **Overwriting when you can edit** — `edit_content` is almost always safer
-- **Skipping transactions for multi-file changes** — partial failures corrupt state
+- **Calling write tools without an active transaction** (when git tracking is on) — every write requires one, even single-file edits; you'll get `TransactionError: No active transaction`
 - **Ignoring SHA mismatches** — they mean the file changed; re-read before retrying
 - **Searching with single keywords** — semantic search needs natural language
 - **Assuming tool availability** — check the tool list before planning workflows that depend on git history or search

--- a/skills/stash-mcp/skills/stash-mcp-usage/SKILL.md
+++ b/skills/stash-mcp/skills/stash-mcp-usage/SKILL.md
@@ -66,12 +66,16 @@ Use `overwrite_content` only when regenerating an entire file from scratch.
 
 ### 3. Transactions Wrap Every Write (when git tracking is on)
 
-When the server has git tracking enabled, every write tool — even a single `create_content` or `edit_content` — requires an active transaction owned by your session. Calling a write tool without one raises `TransactionError: No active transaction`. The choreography is the same whether you're touching one file or twenty:
+When the server has git tracking enabled, every write tool requires an active transaction owned by your session — `create_content`, `overwrite_content`, `edit_content`, `edit_content_batch`, `delete_content`, `move_content`, `move_content_batch`, and `move_content_directory` are all gated. Calling any of them without an active transaction raises:
+
+> `TransactionError: No active transaction. Call start_content_transaction first.`
+
+The choreography is the same whether you're touching one file or twenty:
 
 ```
 list_content_transactions()    → check for orphans first
 start_content_transaction()    → acquire the global lock
-[... one or more create, edit, delete, move operations ...]
+[... one or more write operations (create/overwrite/edit/delete/move, including batch variants) ...]
 commit_content_transaction(message="descriptive commit message")
 ```
 
@@ -100,7 +104,7 @@ See `references/search-strategy.md` for detailed guidance.
 
 - **Reading entire files when you only need structure** — use `inspect_content_structure`
 - **Overwriting when you can edit** — `edit_content` is almost always safer
-- **Calling write tools without an active transaction** (when git tracking is on) — every write requires one, even single-file edits; you'll get `TransactionError: No active transaction`
+- **Calling write tools without an active transaction** (when git tracking is on) — every write requires one, even single-file edits; you'll get `TransactionError: No active transaction. Call start_content_transaction first.`
 - **Ignoring SHA mismatches** — they mean the file changed; re-read before retrying
 - **Searching with single keywords** — semantic search needs natural language
 - **Assuming tool availability** — check the tool list before planning workflows that depend on git history or search

--- a/skills/stash-mcp/skills/stash-mcp-usage/references/tool-reference.md
+++ b/skills/stash-mcp/skills/stash-mcp-usage/references/tool-reference.md
@@ -102,7 +102,11 @@ Rename or relocate files and directories.
 
 ## Transactions
 
-When git tracking is enabled and the server is not in read-only mode, **every write tool requires an active transaction owned by the calling session**. This applies to single-file edits as well as multi-file changes — calling `create_content`, `edit_content`, `delete_content`, or `move_content` (and their batch variants) without one raises `TransactionError: No active transaction`. Transactions provide a global write lock and atomic commit semantics.
+When git tracking is enabled and the server is not in read-only mode, **every write tool requires an active transaction owned by the calling session**. The gated set is `create_content`, `overwrite_content`, `edit_content`, `edit_content_batch`, `delete_content`, `move_content`, `move_content_batch`, and `move_content_directory`. This applies equally to single-file edits and multi-file changes — any of these without an active transaction raises:
+
+> `TransactionError: No active transaction. Call start_content_transaction first.`
+
+Transactions provide a global write lock and atomic commit semantics.
 
 When git tracking is **off**, writes go directly to disk and these transaction tools are not registered.
 

--- a/skills/stash-mcp/skills/stash-mcp-usage/references/tool-reference.md
+++ b/skills/stash-mcp/skills/stash-mcp-usage/references/tool-reference.md
@@ -102,7 +102,9 @@ Rename or relocate files and directories.
 
 ## Transactions
 
-Transactions provide a global write lock and atomic commit semantics. Only available when git tracking is enabled and the server is not in read-only mode.
+When git tracking is enabled and the server is not in read-only mode, **every write tool requires an active transaction owned by the calling session**. This applies to single-file edits as well as multi-file changes — calling `create_content`, `edit_content`, `delete_content`, or `move_content` (and their batch variants) without one raises `TransactionError: No active transaction`. Transactions provide a global write lock and atomic commit semantics.
+
+When git tracking is **off**, writes go directly to disk and these transaction tools are not registered.
 
 ### list_content_transactions()
 

--- a/skills/stash-mcp/skills/stash-mcp-usage/references/workflow-patterns.md
+++ b/skills/stash-mcp/skills/stash-mcp-usage/references/workflow-patterns.md
@@ -54,7 +54,9 @@ edit_content(path, sha, edits=[
 
 ## Pattern: Transactional Write
 
-**When:** Every write, whenever git tracking is enabled — single edits, multi-file reorganizations, template-based creation, anything that calls `create_content` / `edit_content` / `delete_content` / `move_content`. Write tools without an active transaction will fail with `TransactionError: No active transaction`.
+**When:** Every write, whenever git tracking is enabled — single edits, multi-file reorganizations, template-based creation, or any call to a mutating tool. The gated set is `create_content`, `overwrite_content`, `edit_content`, `edit_content_batch`, `delete_content`, `move_content`, `move_content_batch`, and `move_content_directory`. Any of these without an active transaction fails with:
+
+> `TransactionError: No active transaction. Call start_content_transaction first.`
 
 ```
 list_content_transactions()
@@ -65,7 +67,7 @@ list_content_transactions()
 start_content_transaction()
   → acquire the global write lock
 
-[... one or more create/edit/delete/move operations ...]
+[... one or more write operations (create/overwrite/edit/delete/move, including batch variants) ...]
 
 commit_content_transaction(message="descriptive message about what changed and why")
   → atomic commit of all changes

--- a/skills/stash-mcp/skills/stash-mcp-usage/references/workflow-patterns.md
+++ b/skills/stash-mcp/skills/stash-mcp-usage/references/workflow-patterns.md
@@ -52,9 +52,9 @@ edit_content(path, sha, edits=[
 - Edits are sequential — edit #2 sees the result of edit #1. Plan accordingly.
 - SHA mismatch means the file changed. Re-read, check the diff, then retry.
 
-## Pattern: Transactional Multi-File Change
+## Pattern: Transactional Write
 
-**When:** Any operation touching more than one file. Reorganizations, template-based creation, coordinated updates.
+**When:** Every write, whenever git tracking is enabled — single edits, multi-file reorganizations, template-based creation, anything that calls `create_content` / `edit_content` / `delete_content` / `move_content`. Write tools without an active transaction will fail with `TransactionError: No active transaction`.
 
 ```
 list_content_transactions()
@@ -65,13 +65,13 @@ list_content_transactions()
 start_content_transaction()
   → acquire the global write lock
 
-[... multiple create/edit/delete/move operations ...]
+[... one or more create/edit/delete/move operations ...]
 
 commit_content_transaction(message="descriptive message about what changed and why")
   → atomic commit of all changes
 ```
 
-**Why:** Without transactions, a failure after modifying 3 of 5 files leaves the store inconsistent. Transactions ensure all-or-nothing. They also batch all changes into a single git commit, keeping history clean.
+**Why:** With git tracking on, every write is wrapped in a transaction so each change becomes a clean git commit with attribution. Batching multiple operations into one transaction yields one atomic commit instead of many — useful for reorganizations and template-based creation where a half-applied set of changes would leave the store inconsistent.
 
 **Watch for:**
 - Always check for orphans first. A crashed session may have left a lock open.


### PR DESCRIPTION
## Summary

The `stash-mcp-usage` skill described transactions as a pattern for multi-file changes. In reality, when git tracking is enabled the server wraps the filesystem in [`TransactionManager`](https://github.com/dylanturn/Stash-MCP/blob/main/stash_mcp/transactions.py), and *every* mutating call (`create_content`, `edit_content`, `delete_content`, `move_content`, and their batch variants) calls `_require_active_transaction()`. A single-file edit without an active transaction fails with:

> `TransactionError: No active transaction. Call start_content_transaction first.`

Agents following the previous wording would think single-file edits could skip the transaction dance and get bounced by that error.

## Changes

- **`skills/stash-mcp/skills/stash-mcp-usage/SKILL.md`**
  - Mental Model bullet — reframed from "optional global write lock for atomic multi-file changes" to "every write requires an active transaction" when git tracking is on
  - Principle 3 renamed `Transactions for Multi-File Changes` → `Transactions Wrap Every Write`; quotes the exact `TransactionError` message and notes the git-tracking-off case (writes go straight to disk, transaction tools aren't registered)
  - Anti-pattern bullet updated to "Calling write tools without an active transaction"
- **`skills/.../references/workflow-patterns.md`** — pattern renamed `Transactional Multi-File Change` → `Transactional Write`; multi-file reorganizations now framed as one case within the broader rule, not the trigger
- **`skills/.../references/tool-reference.md`** — Transactions section now leads with the requirement and the resulting error explicitly

No behavior change in the server itself — purely correcting the skill docs to match the actual code.

## Test plan

- [ ] Re-read the updated SKILL.md and confirm Principle 3 reads correctly
- [ ] Confirm a fresh session loading the skill won't try a write without a transaction when git tracking is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)