### PR TITLE
Fix Dockerfile arch mismatch by using uv image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM python:3.12-slim
+# Use the official uv image as the base so `uv` is already present and
+# matches the target platform automatically when building with buildx.
+# Previously this Dockerfile did `FROM python:3.12-slim` and then
+# `COPY --from=ghcr.io/astral-sh/uv:latest /uv ...`, which resolved the
+# uv binary against the *builder's* platform rather than the target,
+# producing `exec format error` on mismatched architectures (e.g. an
+# arm64 build run on amd64 nodes).
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 # Set working directory
 WORKDIR /app
-
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \


### PR DESCRIPTION
## Summary

- Switch the base image from `python:3.12-slim` to `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` so the `uv` binary is part of the base layer and matches the target platform automatically.
- Drop the `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/` line — no longer needed.

## Why

I hit this running the published image on a Kubernetes node:

```
exec /usr/local/bin/uv: exec format error
stream closed: EOF for piegpt/piegpt-01-stash-mcp-... (piegpt-01-stash-mcp)
```

The current Dockerfile pulls `python:3.12-slim` (which buildx resolves to the **target** platform) and then uses `COPY --from=ghcr.io/astral-sh/uv:latest /uv ...` to bring in `uv`. With buildx, `COPY --from` resolves the source image against the **builder's** platform rather than the target, so a build run on an arm64 host (e.g. an M-series Mac without `--platform=linux/amd64`) produces an image whose `python` is amd64 but whose `uv` is arm64 — exactly the symptom above when the image is pulled to an amd64 node. The reverse breaks too.

Using the official `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` image as the base sidesteps the problem entirely: buildx picks the correct arch variant from the multi-arch manifest for the target platform, so `uv` and `python` always match. This also mirrors the pattern we use for similar uv-based services internally.

The image already includes `uv` and `uvx`, so the explicit `COPY --from` is now redundant.

## Test plan

- [ ] `docker buildx build --platform linux/amd64 -t stash-mcp:amd64 .` succeeds.
- [ ] `docker buildx build --platform linux/arm64 -t stash-mcp:arm64 .` succeeds.
- [ ] `docker run --rm stash-mcp:<host-arch> uv --version` prints a version (no `exec format error`).
- [ ] Container starts and `/api/health` responds on port 8000.