### PR TITLE
Embed-by-reference for OpenAPI + HTML fragments in markdown

### DIFF
--- a/plugins/stash-mcp/skills/stash-mcp-usage/SKILL.md
+++ b/plugins/stash-mcp/skills/stash-mcp-usage/SKILL.md
@@ -8,7 +8,7 @@ description: >
   edit_content, search_content, list_content, move_content, etc.).
   Teaches efficient navigation, surgical editing, transaction safety,
   and semantic search strategy.
-version: 0.1.4
+version: 0.1.7
 ---
 
 # Stash-MCP Usage Guide
@@ -36,9 +36,9 @@ Stash stores files as-is on disk. Anything text-based round-trips losslessly thr
 |-------|------------|-------|
 | **Markdown** (primary) | `.md`, `.markdown` | First-class. Heading hierarchy parsed by `inspect_content_structure`. Only `README.md` surfaces as an MCP resource — everything else is tool-only. |
 | **Diagrams** | `.mmd`, `.mermaid`, `.gantt` | Rendered as diagrams in the UI viewer. Plain text under the hood — edit like any text file. `.gantt` is YAML-based. |
-| **API specs** | `.json` with an `openapi` root key | Rendered as an OpenAPI viewer in the UI. Stored as plain JSON. |
+| **API specs** | `.json` with an `openapi` root key | Rendered as an OpenAPI viewer in the UI. Stored as plain JSON. Slices can be embedded into markdown via ` ```stash-embed ` — see below. |
 | **Tabular** | `.csv`, `.tsv` | Rendered as HTML tables in the UI. |
-| **Web** | `.html`, `.htm` | Rendered in a sandboxed iframe. |
+| **Web** | `.html`, `.htm` | Rendered in a sandboxed iframe. Fragments can also be embedded into markdown via ` ```stash-embed ` (CSS selector). |
 | **Structured text** | `.json`, `.yaml`, `.yml`, `.toml`, `.xml`, `.ini`, `.cfg` | Stored as text, no special rendering. |
 | **Code** | `.py`, `.js`, `.ts`, `.css`, `.rst`, `.txt`, `.log`, plus any other text extension | Stored as text. Searchable. |
 | **Image assets** | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.ico`, `.bmp` | Served via `/ui/raw/<path>` for embedding. Do **not** `read_content` these — store and link instead. |
@@ -53,6 +53,38 @@ Markdown is the host format — several other types can be embedded inline so a 
 - **Mermaid diagrams** — fenced code block tagged ` ```mermaid ` renders inline. Use this for one-off diagrams; reserve standalone `.mmd` files for diagrams you want to reuse or link to.
 - **Gantt charts** — fenced code block tagged ` ```gantt ` (YAML body) renders inline. Standalone `.gantt` files work the same way. **The YAML schema is Stash-specific** (not Mermaid gantt syntax) — see `references/gantt-format.md` before authoring.
 - **CSV / TSV tables** — fenced code block tagged ` ```csv ` or ` ```tsv ` renders as an HTML table inline. Good for small, document-scoped tables; use standalone `.csv` files when the data is the artifact.
+- **Embed-by-reference** — fenced code block tagged ` ```stash-embed ` (YAML body) renders a slice of another document inline. The source stays the single source of truth; edits there propagate to every embed.
+
+  **Shared fields:**
+  - `src:` (required) — path to the source file. Absolute paths (`/specs/orders.json`) are rooted at the content store; relative paths resolve against the embedding document's directory.
+  - `type:` (optional) — override auto-detection. Supported values: `openapi`, `html`. Auto-detection uses the `src` extension plus content sniffing; set `type:` explicitly when the extension is ambiguous (e.g. an HTML snippet stored as `.txt`).
+
+  **OpenAPI sources** (`.json` / `.yaml` / `.yml` with a top-level `openapi` key):
+  - `tag:` — keep only operations tagged with this value.
+  - `path:` — keep only this exact path (e.g. `/orders/{order_id}`).
+  - `operationId:` — keep only this single operation.
+
+  Filters combine with AND. With no filters, the full spec renders. Filtered embeds drop the `components.schemas` block since the point is a focused slice.
+
+  **HTML sources** (`.html` / `.htm`):
+  - `selector:` — any CSS selector (id, class, tag, attribute, combinators all work). Returns the matched subtree(s). With no selector, returns the document `<body>` contents.
+
+  `<style>` blocks from the source are preserved and re-emitted wrapped in a CSS `@scope` rule keyed to a per-embed class, so the source's styling applies only to its own fragment and doesn't leak into the host doc. Multiple embeds from different sources can use the same generic selectors (e.g. `section { ... }`) without colliding. Requires a browser with `@scope` support (Chrome/Edge 118+, Safari 17.4+, Firefox 128+).
+
+  **Examples:**
+  ````markdown
+  ```stash-embed
+  src: /specs/orders.json
+  tag: orders
+  ```
+
+  ```stash-embed
+  src: /reports/q2.html
+  selector: "#risks"
+  ```
+  ````
+
+  **Errors** render inline (missing `src`, source not found, no selector match, ambiguous type, etc.) — they never silently drop content. If you see a red error box in a rendered doc, fix the embed reference.
 - **Raw HTML** — passes through the markdown renderer by design. `<details>`, `<img>`, `<video>`, `<iframe>`, `<div>` all work. Use sparingly; markdown syntax is preferable when it covers the case.
 
 **Cannot be embedded inline:** PDFs, Office documents (`.docx`, `.xlsx`, `.pptx`), Jupyter notebooks (`.ipynb`), and other binary formats. Link to them as assets if needed, but Stash has no native renderer for these — `read_content` will return unreadable bytes.

--- a/plugins/stash-mcp/skills/stash-mcp-usage/SKILL.md
+++ b/plugins/stash-mcp/skills/stash-mcp-usage/SKILL.md
@@ -8,7 +8,7 @@ description: >
   edit_content, search_content, list_content, move_content, etc.).
   Teaches efficient navigation, surgical editing, transaction safety,
   and semantic search strategy.
-version: 0.1.7
+version: 0.1.8
 ---
 
 # Stash-MCP Usage Guide
@@ -59,17 +59,21 @@ Markdown is the host format — several other types can be embedded inline so a 
   - `src:` (required) — path to the source file. Absolute paths (`/specs/orders.json`) are rooted at the content store; relative paths resolve against the embedding document's directory.
   - `type:` (optional) — override auto-detection. Supported values: `openapi`, `html`. Auto-detection uses the `src` extension plus content sniffing; set `type:` explicitly when the extension is ambiguous (e.g. an HTML snippet stored as `.txt`).
 
-  **OpenAPI sources** (`.json` / `.yaml` / `.yml` with a top-level `openapi` key):
+  **OpenAPI sources** (`.json` / `.yaml` / `.yml` with a top-level `openapi` key, or any extension with `type: openapi`):
   - `tag:` — keep only operations tagged with this value.
   - `path:` — keep only this exact path (e.g. `/orders/{order_id}`).
   - `operationId:` — keep only this single operation.
 
-  Filters combine with AND. With no filters, the full spec renders. Filtered embeds drop the `components.schemas` block since the point is a focused slice.
+  Filters combine with AND. With no filters, the full spec renders. Filtered embeds drop the `components.schemas` block since the point is a focused slice. Parsing is YAML-based, which is a superset of JSON — both formats work regardless of file extension when `type: openapi` is set explicitly.
 
   **HTML sources** (`.html` / `.htm`):
   - `selector:` — any CSS selector (id, class, tag, attribute, combinators all work). Returns the matched subtree(s). With no selector, returns the document `<body>` contents.
 
-  `<style>` blocks from the source are preserved and re-emitted wrapped in a CSS `@scope` rule keyed to a per-embed class, so the source's styling applies only to its own fragment and doesn't leak into the host doc. Multiple embeds from different sources can use the same generic selectors (e.g. `section { ... }`) without colliding. Requires a browser with `@scope` support (Chrome/Edge 118+, Safari 17.4+, Firefox 128+).
+  `<style>` blocks from the source are preserved and re-emitted wrapped in a CSS `@scope` rule keyed to a per-embed class, so the source's styling applies only to its own fragment and doesn't leak into the host doc. `@keyframes` animations pass through unchanged. Multiple embeds from different sources can use the same generic selectors (e.g. `section { ... }`) without colliding. Requires a browser with `@scope` support (Chrome/Edge 118+, Safari 17.4+, Firefox 128+).
+
+  Relative `src` / `href` attributes inside the embedded fragment resolve relative to the **source file's** directory, not the embedding markdown's. So a `reports/q2.html` containing `<img src="images/foo.png">` renders the image from `reports/images/foo.png` regardless of where the embed is included from.
+
+  **Embedded HTML is not sandboxed.** Standalone `.html` files render inside a sandboxed iframe, but `stash-embed` fragments inject directly into the host document. To prevent script execution in the host's origin, embedded fragments have `<script>` elements, `on*` event-handler attributes (`onclick`, `onmouseover`, etc.), and `javascript:` URL schemes stripped at render time. Styles, `<svg>`, `<canvas>`, and structural markup still work; interactive JS does not. Use a standalone `.html` file if you need scripts.
 
   **Examples:**
   ````markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "markdown>=3.7",
     "pyyaml>=6.0",
     "tinyflux>=1.2.0",
+    "beautifulsoup4>=4.12.0",
 ]
 
 [project.scripts]

--- a/stash_mcp/static/vendor/stash-gantt.js
+++ b/stash_mcp/static/vendor/stash-gantt.js
@@ -124,7 +124,7 @@ window.StashGantt={
     toolbar.className='gantt-toolbar';
     toolbar.innerHTML=
       '<span class="gantt-title">'+(data.title||'Gantt Chart')+'</span>'+
-      '<span class="gantt-hint">Scroll to zoom • Drag background to pan'+(readOnly?'':'  • Drag bars to reschedule')+'</span>'+
+      '<span class="gantt-hint">Pinch to zoom • Drag to pan'+(readOnly?'':' • Shift-drag a bar to reschedule')+'</span>'+
       (!readOnly&&savePath?'<button class="gantt-save-btn" disabled>Save changes</button>':'');
     container.appendChild(toolbar);
 
@@ -162,6 +162,17 @@ window.StashGantt={
       /* background */
       var bg=el('rect',{x:0,y:0,width:chartW,height:chartH,fill:C.mantle,rx:6});
       svg.appendChild(bg);
+
+      /* clip path keeping bars/arrows out of the label column.
+         A fresh id per draw avoids stale refs across redraws. */
+      var defs=document.createElementNS('http://www.w3.org/2000/svg','defs');
+      var clipId='gantt-clip-'+Math.random().toString(36).slice(2,10);
+      var clipPath=document.createElementNS('http://www.w3.org/2000/svg','clipPath');
+      clipPath.setAttribute('id',clipId);
+      clipPath.appendChild(el('rect',{x:LABEL_W,y:HEADER_H,width:chartW-LABEL_W,height:chartH-HEADER_H}));
+      defs.appendChild(clipPath);
+      svg.appendChild(defs);
+      var chartArea=elG({'clip-path':'url(#'+clipId+')'});
 
       /* time axis */
       var daySpan=diffDays(state.viewMin,state.viewMax);
@@ -229,7 +240,7 @@ window.StashGantt={
             barG.appendChild(elText(dStr,x2-8,barY+barH/2+4,{fill:C.crust,'font-size':'10px','text-anchor':'end',opacity:0.7}));
           }
 
-          svg.appendChild(barG);
+          chartArea.appendChild(barG);
           y+=ROW_H;
         });
       });
@@ -254,14 +265,19 @@ window.StashGantt={
         if(fromY&&toY){
           var midX=fromX+(toX-fromX)/2;
           var path='M'+fromX+' '+fromY+' C'+midX+' '+fromY+' '+midX+' '+toY+' '+toX+' '+toY;
-          svg.appendChild(el('path',{d:path,fill:'none',stroke:C.overlay0,'stroke-width':1.5,'marker-end':'url(#arrow)'}));
+          chartArea.appendChild(el('path',{d:path,fill:'none',stroke:C.overlay0,'stroke-width':1.5,'marker-end':'url(#arrow)'}));
         }
       });
 
       /* arrow marker def */
-      var defs=document.createElementNS('http://www.w3.org/2000/svg','defs');
-      defs.innerHTML='<marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="'+C.overlay0+'"/></marker>';
-      svg.appendChild(defs);
+      var markerDefs=document.createElementNS('http://www.w3.org/2000/svg','defs');
+      markerDefs.innerHTML='<marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="'+C.overlay0+'"/></marker>';
+      svg.appendChild(markerDefs);
+
+      /* Append the clipped chart-area group last so its content (bars + dep
+         arrows) renders above the row stripes and section bands, while the
+         clip path keeps every bar pixel out of the left-hand label column. */
+      svg.appendChild(chartArea);
     }
 
     /* ── events ── */
@@ -297,40 +313,37 @@ window.StashGantt={
       draw();
     });
 
-    /* drag to reschedule */
-    if(!readOnly){
-      svg.addEventListener('mousedown',function(e){
-        var bar=e.target.closest('.gantt-bar');
-        if(bar){
-          e.preventDefault();
-          var id=bar.getAttribute('data-id');
-          var task=state.resolved.taskMap[id];
-          if(!task)return;
-          state.dragging=id;
-          state.dragStartX=e.clientX;
-          state.dragOrigStart=new Date(task._start);
-          state.dragOrigEnd=new Date(task._end);
-          state.selected=id;
-          svg.style.cursor='grabbing';
-          draw();
-          return;
-        }
-        /* pan on background */
-        state.panning=true;
-        state.panStartX=e.clientX;
-        state.panViewMin=new Date(state.viewMin);
-        state.panViewMax=new Date(state.viewMax);
-        svg.style.cursor='move';
-      });
-    }else{
-      svg.addEventListener('mousedown',function(e){
-        state.panning=true;
-        state.panStartX=e.clientX;
-        state.panViewMin=new Date(state.viewMin);
-        state.panViewMax=new Date(state.viewMax);
-        svg.style.cursor='move';
-      });
-    }
+    /* default cursor signals draggability, matching mermaid's grab/grabbing UX. */
+    wrap.style.cursor='grab';
+
+    /* mousedown:
+     *   default → pan anywhere on the chart (matches mermaid pan UX).
+     *   shift+mousedown on a bar (non-readonly) → reschedule that bar.
+     *   click without drag still selects the bar (handled by the click listener
+     *   above; mousedown that doesn't move beyond a few pixels stays a click). */
+    svg.addEventListener('mousedown',function(e){
+      var bar=e.target.closest('.gantt-bar');
+      if(!readOnly && bar && e.shiftKey){
+        e.preventDefault();
+        var id=bar.getAttribute('data-id');
+        var task=state.resolved.taskMap[id];
+        if(!task)return;
+        state.dragging=id;
+        state.dragStartX=e.clientX;
+        state.dragOrigStart=new Date(task._start);
+        state.dragOrigEnd=new Date(task._end);
+        state.selected=id;
+        svg.style.cursor='grabbing';
+        draw();
+        return;
+      }
+      state.panning=true;
+      state.panStartX=e.clientX;
+      state.panViewMin=new Date(state.viewMin);
+      state.panViewMax=new Date(state.viewMax);
+      svg.style.cursor='grabbing';
+      e.preventDefault();
+    });
 
     document.addEventListener('mousemove',function(e){
       if(state.dragging){
@@ -359,34 +372,60 @@ window.StashGantt={
         state.dirty=true;
         if(saveBtn)saveBtn.disabled=false;
         state.dragging=null;
-        svg.style.cursor='';
+        svg.style.cursor='grab';
       }
       if(state.panning){
         state.panning=false;
-        svg.style.cursor='';
+        svg.style.cursor='grab';
       }
     });
 
-    /* scroll to zoom */
+    /* wheel handler:
+     *   ctrlKey set → trackpad pinch (browser convention) or ctrl+wheel: zoom
+     *     the time range around the cursor using a smooth exponential curve.
+     *   otherwise → do nothing; let the wheel scroll the surrounding page.
+     *     Panning is mouse-drag only, matching mermaid's wheel UX. */
     wrap.addEventListener('wheel',function(e){
+      if(!e.ctrlKey)return;
       e.preventDefault();
-      var zoomFactor=e.deltaY>0?1.15:0.87;
       var rect=wrap.getBoundingClientRect();
+      var span=state.viewMax-state.viewMin;
+      var minSpan=7*864e5,maxSpan=365*3*864e5;
+      var zoomFactor=Math.exp(e.deltaY*0.01);
       var mouseX=e.clientX-rect.left;
       var ratio=(mouseX-LABEL_W)/state._timeW;
       if(ratio<0)ratio=0;if(ratio>1)ratio=1;
-
-      var span=state.viewMax-state.viewMin;
       var newSpan=span*zoomFactor;
-      var minSpan=7*864e5;var maxSpan=365*3*864e5;
       if(newSpan<minSpan)newSpan=minSpan;
       if(newSpan>maxSpan)newSpan=maxSpan;
-
       var pivot=state.viewMin.getTime()+span*ratio;
       state.viewMin=new Date(pivot-newSpan*ratio);
       state.viewMax=new Date(pivot+newSpan*(1-ratio));
       draw();
     },{passive:false});
+
+    /* Safari trackpad pinch */
+    var gestureSpan=0,gestureRatio=0,gestureViewMin=null;
+    wrap.addEventListener('gesturestart',function(e){
+      e.preventDefault();
+      gestureSpan=state.viewMax-state.viewMin;
+      var rect=wrap.getBoundingClientRect();
+      var mouseX=e.clientX-rect.left;
+      gestureRatio=Math.min(Math.max((mouseX-LABEL_W)/state._timeW,0),1);
+      gestureViewMin=new Date(state.viewMin);
+    });
+    wrap.addEventListener('gesturechange',function(e){
+      e.preventDefault();
+      var minSpan=7*864e5,maxSpan=365*3*864e5;
+      var newSpan=gestureSpan/e.scale;
+      if(newSpan<minSpan)newSpan=minSpan;
+      if(newSpan>maxSpan)newSpan=maxSpan;
+      var pivot=gestureViewMin.getTime()+gestureSpan*gestureRatio;
+      state.viewMin=new Date(pivot-newSpan*gestureRatio);
+      state.viewMax=new Date(pivot+newSpan*(1-gestureRatio));
+      draw();
+    });
+    wrap.addEventListener('gestureend',function(e){e.preventDefault();});
 
     /* save button */
     if(saveBtn&&savePath){

--- a/stash_mcp/ui.py
+++ b/stash_mcp/ui.py
@@ -636,12 +636,16 @@ def _infer_embed_type(src: str, raw: str, suffix: str) -> str | None:
 
 
 def _render_openapi_embed(raw: str, src: str, suffix: str, config: dict) -> str:
-    """Render an OpenAPI fragment for inline embedding."""
+    """Render an OpenAPI fragment for inline embedding.
+
+    YAML 1.1 is a superset of JSON, so a single `yaml.safe_load` parses both —
+    important because `type: openapi` overrides let users embed YAML specs
+    stored under ambiguous extensions (e.g. `.txt`) where suffix-based parser
+    selection would have wrongly defaulted to JSON.
+    """
+    del suffix  # parser is now extension-agnostic
     try:
-        if suffix in (".yaml", ".yml"):
-            spec = _yaml.safe_load(raw)
-        else:
-            spec = _json.loads(raw)
+        spec = _yaml.safe_load(raw)
     except (ValueError, _yaml.YAMLError) as exc:
         return _embed_error(f"failed to parse '{src}': {exc}")
     if not isinstance(spec, dict) or "openapi" not in spec:
@@ -688,6 +692,55 @@ _ROOT_SELECTOR_RE = re.compile(
 # — their inner rules are matched in subsequent iterations.
 _RULE_HEAD_RE = re.compile(r"(^|[\}\{])([^@\}\{]+?)\{", re.MULTILINE)
 
+# Matches the `@keyframes <name>` (or vendor-prefixed) start of a keyframes
+# at-rule. Keyframes step lists (`0% { ... }`, `from { ... }`, `to { ... }`)
+# are NOT selectors and must not be prefixed with `:scope` — doing so produces
+# invalid CSS and silently breaks animations. We extract the whole keyframes
+# block by tracking brace depth, then splice it back unchanged after scoping.
+_KEYFRAMES_START_RE = re.compile(
+    r"@(?:-webkit-|-moz-|-o-|-ms-)?keyframes\b", re.IGNORECASE,
+)
+
+
+def _extract_keyframes(css: str) -> tuple[str, dict[str, str]]:
+    """Replace each `@keyframes` block with a placeholder. Returns the
+    placeholder-substituted CSS and a mapping of placeholders to original
+    block text.
+
+    The placeholder is itself an empty at-rule (`@stash-kf-N{}`) so that the
+    later selector-rewriting pass ignores it (`_RULE_HEAD_RE` skips selector
+    portions that contain `@`) and treats the trailing `}` as a clean boundary
+    before the next real rule.
+    """
+    placeholders: dict[str, str] = {}
+    out: list[str] = []
+    i = 0
+    while i < len(css):
+        m = _KEYFRAMES_START_RE.search(css, i)
+        if not m:
+            out.append(css[i:])
+            break
+        out.append(css[i:m.start()])
+        # Find the opening brace; if none, give up and emit verbatim.
+        brace = css.find("{", m.end())
+        if brace < 0:
+            out.append(css[m.start():])
+            break
+        depth = 1
+        j = brace + 1
+        while j < len(css) and depth > 0:
+            ch = css[j]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            j += 1
+        token = f"@stash-kf-{len(placeholders)}{{}}"
+        placeholders[token] = css[m.start():j]
+        out.append(token)
+        i = j
+    return "".join(out), placeholders
+
 
 def _scope_css_selectors(css: str) -> str:
     """Rewrite every non-@-rule selector in `css` so it gains class-level
@@ -699,7 +752,12 @@ def _scope_css_selectors(css: str) -> str:
        host's `.markdown-body h2 { color: ... }` (specificity 0,1,1) beats the
        source's naked `h2 { ... }` (0,0,1) and headings render in the host's
        color instead of the source's.
+
+    `@keyframes` blocks are extracted first and spliced back unchanged so we
+    don't try to rewrite their step lists (`0%`, `from`, `to`) as selectors.
     """
+    css, keyframes = _extract_keyframes(css)
+
     def _rewrite(match: re.Match) -> str:
         boundary = match.group(1)
         selectors = match.group(2)
@@ -716,7 +774,10 @@ def _scope_css_selectors(css: str) -> str:
             parts.append(stripped)
         return f"{boundary}{', '.join(parts)} {{"
 
-    return _RULE_HEAD_RE.sub(_rewrite, css)
+    rewritten = _RULE_HEAD_RE.sub(_rewrite, css)
+    for token, block in keyframes.items():
+        rewritten = rewritten.replace(token, block)
+    return rewritten
 
 
 # Defensive reset injected into every styled HTML embed. Each `:scope <el>`
@@ -745,7 +806,57 @@ _EMBED_HOST_STYLE_RESET = (
 )
 
 
-def _render_html_embed(raw: str, src: str, config: dict) -> str:
+def _sanitize_embed_dom(soup) -> None:
+    """In-place: strip scripts and inline event handlers from an embed tree.
+
+    Standalone `.html` files render in a sandboxed iframe (see the
+    `serve_browse` route). Embedded fragments, however, are injected directly
+    into the host document — they share the UI page's origin and have access
+    to its DOM. To keep embed semantics closer to the sandboxed view (and to
+    defend against accidentally executing scripts from un-vetted HTML in the
+    content store), we remove:
+
+      - `<script>` elements
+      - Any `on*` event-handler attribute (onclick, onerror, etc.)
+      - `href`/`src`/`xlink:href`/`action` values that use the `javascript:`
+        scheme
+
+    Styles are intentionally kept — they're already isolated via `@scope`.
+    """
+    for tag in list(soup.find_all("script")):
+        tag.decompose()
+    for tag in soup.find_all(True):
+        # Iterate over a snapshot of attr keys; we mutate the dict in-place.
+        for attr in list(tag.attrs.keys()):
+            if attr.lower().startswith("on"):
+                del tag.attrs[attr]
+            elif attr.lower() in ("href", "src", "xlink:href", "action", "formaction"):
+                value = tag.attrs[attr]
+                if isinstance(value, list):
+                    value = " ".join(value)
+                if isinstance(value, str) and value.strip().lower().startswith("javascript:"):
+                    del tag.attrs[attr]
+
+
+def _rewrite_embed_relative_urls(html_str: str, embed_dir: str) -> str:
+    """Rewrite relative `src`/`href` in an embed fragment to absolute
+    `/ui/raw/...` paths anchored at the embed source's directory.
+
+    The host markdown's `_rewrite_relative_urls` runs once over the final
+    rendered document, but it uses the *embedding markdown's* base_dir — so
+    relative URLs inside an embed (e.g. `images/foo.png` inside
+    `reports/q2.html`) would resolve under the markdown's folder instead of
+    the HTML source's folder. Rewriting here, before insertion, turns them
+    into absolute paths that the later pass leaves alone.
+    """
+    if not embed_dir or embed_dir == ".":
+        # Source sits at the content root; relatives already resolve correctly
+        # via the later pass with base_dir="".
+        return _rewrite_relative_urls(html_str, "")
+    return _rewrite_relative_urls(html_str, embed_dir)
+
+
+def _render_html_embed(raw: str, src: str, embed_dir: str, config: dict) -> str:
     """Render an HTML fragment for inline embedding.
 
     With `selector:`, returns the matched subtree(s). Without, returns the
@@ -756,6 +867,10 @@ def _render_html_embed(raw: str, src: str, config: dict) -> str:
     fragment without leaking into the host document. A short hash of
     (src, selector) keys the scope class so multiple embeds from different
     sources don't collide on shared selectors like `section { ... }`.
+
+    Scripts and event-handler attributes are stripped (see
+    `_sanitize_embed_dom`), and relative URLs are rewritten relative to the
+    source's directory (`embed_dir`).
     """
     import hashlib
 
@@ -774,6 +889,8 @@ def _render_html_embed(raw: str, src: str, config: dict) -> str:
     combined_css = "\n".join(str(s.string or "") for s in style_blocks).strip()
     for s in style_blocks:
         s.decompose()
+
+    _sanitize_embed_dom(soup)
 
     # Always emit the reset — even when the source has no <style> block at
     # all. Without this, sources like a bare `<div>...<code>...</code></div>`
@@ -796,6 +913,8 @@ def _render_html_embed(raw: str, src: str, config: dict) -> str:
     else:
         body = soup.body
         fragment = body.decode_contents() if body else str(soup)
+
+    fragment = _rewrite_embed_relative_urls(fragment, embed_dir)
 
     digest = hashlib.sha256(f"{src}|{selector or ''}".encode()).hexdigest()[:10]
     scope_class = f"embed-{digest}"
@@ -852,7 +971,13 @@ def _make_embed_replacer(filesystem: "FileSystem | None", base_dir: str):
         if embed_type == "openapi":
             return _render_openapi_embed(raw, src, suffix, config)
         if embed_type == "html":
-            return _render_html_embed(raw, src, config)
+            # The embed source's parent dir — used to resolve relative URLs
+            # inside the fragment so e.g. `<img src="images/foo.png">` in
+            # `reports/q2.html` resolves under `reports/`, not the embedding
+            # markdown's folder.
+            parent = PurePosixPath(resolved).parent
+            embed_dir = "" if str(parent) in ("", ".") else str(parent)
+            return _render_html_embed(raw, src, embed_dir, config)
         return _embed_error(f"unknown embed type '{embed_type}' (supported: openapi, html)")
 
     return _replace

--- a/stash_mcp/ui.py
+++ b/stash_mcp/ui.py
@@ -8,7 +8,7 @@ import json as _json
 import logging
 import re
 from datetime import UTC, datetime
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 import markdown as md
 import yaml as _yaml
@@ -16,8 +16,26 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from .events import CONTENT_CREATED, CONTENT_DELETED, CONTENT_MOVED, CONTENT_UPDATED, emit
+from .filesystem import FileNotFoundError as FSFileNotFoundError
 from .filesystem import FileSystem
 from .mcp_server import MIME_TYPES
+
+_STATIC_DIR = Path(__file__).parent / "static"
+
+
+def _static_url(rel_path: str) -> str:
+    """Return a `/static/...` URL with an mtime-based cache buster.
+
+    Browsers cache `/static/*` aggressively. Appending the file's mtime as a
+    query string means any edit to a shipped asset invalidates the cache on
+    next page load — no hard-refresh required.
+    """
+    try:
+        mtime = int((_STATIC_DIR / rel_path).stat().st_mtime)
+    except OSError:
+        mtime = 0
+    return f"/static/{rel_path}?v={mtime}"
+
 
 _IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp"})
 _SVG_EXTENSIONS = frozenset({".svg"})
@@ -528,7 +546,323 @@ def _csv_fence_replace(m: re.Match) -> str:
         return m.group(0)
 
 
-def _render_markdown(content: str) -> tuple[str, str]:
+_EMBED_FENCE_RE = re.compile(
+    r"^```stash-embed\s*\n(?P<body>.*?)^```\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _embed_error(message: str) -> str:
+    return f'<div class="error-msg">Embed error: {html.escape(message)}</div>'
+
+
+def _resolve_embed_src(src: str, base_dir: str) -> str:
+    """Resolve an embed `src` to a content-store-relative path.
+
+    Absolute (`/specs/api.json`) is rooted at the content store; otherwise the
+    src is interpreted relative to the embedding document's directory.
+    """
+    if src.startswith("/"):
+        return src.lstrip("/")
+    if base_dir:
+        return str(PurePosixPath(base_dir) / src)
+    return src
+
+
+def _filter_openapi_spec(
+    spec: dict,
+    *,
+    tag: str | None = None,
+    path_filter: str | None = None,
+    operation_id: str | None = None,
+) -> dict:
+    """Return a copy of `spec` containing only paths/operations matching the filters.
+
+    With no filters set, returns the spec unchanged. When filters are applied,
+    `components.schemas` is dropped from the embedded view — embeds are meant
+    to show a focused slice, and the schemas block doubles the rendered height.
+    """
+    if not (tag or path_filter or operation_id):
+        return spec
+
+    filtered_paths: dict = {}
+    for route, methods in spec.get("paths", {}).items():
+        if path_filter and route != path_filter:
+            continue
+        if not isinstance(methods, dict):
+            continue
+        kept: dict = {}
+        for method, op in methods.items():
+            if not isinstance(op, dict) or method.lower() not in _METHOD_COLORS:
+                continue
+            if tag and tag not in op.get("tags", []):
+                continue
+            if operation_id and op.get("operationId") != operation_id:
+                continue
+            kept[method] = op
+        if kept:
+            filtered_paths[route] = kept
+
+    new_spec = dict(spec)
+    new_spec["paths"] = filtered_paths
+    components = new_spec.get("components")
+    if isinstance(components, dict) and "schemas" in components:
+        trimmed = dict(components)
+        trimmed.pop("schemas", None)
+        new_spec["components"] = trimmed
+    return new_spec
+
+
+_OPENAPI_EXTS = frozenset({".json", ".yaml", ".yml"})
+_HTML_EMBED_EXTS = frozenset({".html", ".htm"})
+
+
+def _infer_embed_type(src: str, raw: str, suffix: str) -> str | None:
+    """Infer embed type from extension + content. Returns None if ambiguous."""
+    if suffix in _HTML_EMBED_EXTS:
+        return "html"
+    if suffix in _OPENAPI_EXTS:
+        # JSON/YAML could be anything; sniff for openapi key.
+        try:
+            if suffix in (".yaml", ".yml"):
+                parsed = _yaml.safe_load(raw)
+            else:
+                parsed = _json.loads(raw)
+        except (ValueError, _yaml.YAMLError):
+            return None
+        if isinstance(parsed, dict) and "openapi" in parsed:
+            return "openapi"
+    return None
+
+
+def _render_openapi_embed(raw: str, src: str, suffix: str, config: dict) -> str:
+    """Render an OpenAPI fragment for inline embedding."""
+    try:
+        if suffix in (".yaml", ".yml"):
+            spec = _yaml.safe_load(raw)
+        else:
+            spec = _json.loads(raw)
+    except (ValueError, _yaml.YAMLError) as exc:
+        return _embed_error(f"failed to parse '{src}': {exc}")
+    if not isinstance(spec, dict) or "openapi" not in spec:
+        return _embed_error(f"'{src}' is not an OpenAPI spec")
+
+    tag = config.get("tag")
+    path_filter = config.get("path")
+    operation_id = config.get("operationId")
+    for name, value in (("tag", tag), ("path", path_filter), ("operationId", operation_id)):
+        if value is not None and not isinstance(value, str):
+            return _embed_error(f"'{name}' must be a string")
+
+    filtered = _filter_openapi_spec(
+        spec, tag=tag, path_filter=path_filter, operation_id=operation_id,
+    )
+    if (tag or path_filter or operation_id) and not filtered.get("paths"):
+        selectors = ", ".join(
+            f"{k}={v}" for k, v in [
+                ("tag", tag), ("path", path_filter), ("operationId", operation_id)
+            ] if v
+        )
+        return _embed_error(f"no operations in '{src}' matched {selectors}")
+
+    try:
+        center_html, _ = _render_openapi(filtered)
+    except Exception as exc:
+        return _embed_error(f"render failed: {exc}")
+    return f'<div class="embedded-openapi">{center_html}</div>'
+
+
+# Matches `body`, `html`, or `:root` when they appear at the start of a CSS
+# selector (start of file, after `}`, or after `,`) and are followed by a token
+# that ends a selector or starts a compound (whitespace, `{`, `,`, `.`, `#`,
+# `:`, `[`, `>`, `~`, `+`). Captures the preceding boundary and any whitespace
+# so they can be re-emitted unchanged.
+_ROOT_SELECTOR_RE = re.compile(
+    r"(^|[\},])(\s*)(?:body|html|:root)(?=[\s\.\#\:\[\>\~\+\,\{]|$)"
+)
+
+# Matches a non-@-rule selector list that ends in `{`. The boundary captures
+# either start-of-file or the closing of the previous block, so we can prepend
+# `:scope ` to every selector inside an `@scope` block. The `[^@\}\{]+?`
+# excludes `@` so we don't try to rewrite `@media` / `@supports` / etc. preludes
+# — their inner rules are matched in subsequent iterations.
+_RULE_HEAD_RE = re.compile(r"(^|[\}\{])([^@\}\{]+?)\{", re.MULTILINE)
+
+
+def _scope_css_selectors(css: str) -> str:
+    """Rewrite every non-@-rule selector in `css` so it gains class-level
+    specificity inside the embed's `@scope (.embed-xxx)` block.
+
+    1. Leading `body` / `html` / `:root` tokens are rewritten to `:scope`.
+    2. Other selectors are prefixed with `:scope ` (descendant combinator) so
+       e.g. `h2 { ... }` becomes `:scope h2 { ... }`. Without this boost the
+       host's `.markdown-body h2 { color: ... }` (specificity 0,1,1) beats the
+       source's naked `h2 { ... }` (0,0,1) and headings render in the host's
+       color instead of the source's.
+    """
+    def _rewrite(match: re.Match) -> str:
+        boundary = match.group(1)
+        selectors = match.group(2)
+        if not selectors.strip():
+            return match.group(0)
+        parts: list[str] = []
+        for raw in selectors.split(","):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            stripped = _ROOT_SELECTOR_RE.sub(r":scope", stripped)
+            if not stripped.startswith(":scope"):
+                stripped = f":scope {stripped}"
+            parts.append(stripped)
+        return f"{boundary}{', '.join(parts)} {{"
+
+    return _RULE_HEAD_RE.sub(_rewrite, css)
+
+
+# Defensive reset injected into every styled HTML embed. Each `:scope <el>`
+# selector has specificity (0,1,1) — ties with host rules like
+# `.markdown-body th { background: #272738 }` and wins by source order, so
+# host CSS doesn't leak into elements the source didn't explicitly style.
+#
+# `all: revert` resets every property of the matched elements to what the
+# user-agent stylesheet would set, ignoring all author styles from earlier in
+# the cascade (i.e., the host). Source rules with the same selector come
+# *after* this reset in the same author origin, so they win on source order
+# and the source's intended styling lands on top. Source class/id rules
+# (specificity 0,2,0+) beat the reset outright. Anything the source doesn't
+# style falls back to UA defaults (transparent bg, browser-default fonts and
+# borders) — i.e., the embed renders like a standalone HTML page.
+_EMBED_HOST_STYLE_RESET = (
+    ":scope h1, :scope h2, :scope h3, :scope h4, :scope h5, :scope h6, "
+    ":scope p, :scope a, :scope li, :scope ul, :scope ol, :scope dl, "
+    ":scope dt, :scope dd, :scope table, :scope thead, :scope tbody, "
+    ":scope tr, :scope th, :scope td, :scope caption, "
+    ":scope blockquote, :scope figure, :scope figcaption, "
+    ":scope code, :scope pre, :scope kbd, :scope samp, :scope var, "
+    ":scope strong, :scope em, :scope b, :scope i, :scope u, :scope s, "
+    ":scope small, :scope mark, :scope label, :scope hr "
+    "{ all: revert; }\n"
+)
+
+
+def _render_html_embed(raw: str, src: str, config: dict) -> str:
+    """Render an HTML fragment for inline embedding.
+
+    With `selector:`, returns the matched subtree(s). Without, returns the
+    document `<body>` (or the whole tree if no body element).
+
+    `<style>` blocks from the source are extracted and re-emitted scoped to a
+    per-embed CSS `@scope` rule, so the source's styling applies to its own
+    fragment without leaking into the host document. A short hash of
+    (src, selector) keys the scope class so multiple embeds from different
+    sources don't collide on shared selectors like `section { ... }`.
+    """
+    import hashlib
+
+    from bs4 import BeautifulSoup
+
+    selector = config.get("selector")
+    if selector is not None and not isinstance(selector, str):
+        return _embed_error("'selector' must be a string")
+
+    try:
+        soup = BeautifulSoup(raw, "html.parser")
+    except Exception as exc:
+        return _embed_error(f"failed to parse '{src}': {exc}")
+
+    style_blocks = soup.find_all("style")
+    combined_css = "\n".join(str(s.string or "") for s in style_blocks).strip()
+    for s in style_blocks:
+        s.decompose()
+
+    # Always emit the reset — even when the source has no <style> block at
+    # all. Without this, sources like a bare `<div>...<code>...</code></div>`
+    # would still have host markdown rules (e.g. `.markdown-body code
+    # { background: #181825 }`) leak through. Source CSS, if present, gets
+    # the `:scope ` specificity boost so it beats host rules too. See
+    # _scope_css_selectors() for the why.
+    if combined_css:
+        combined_css = _scope_css_selectors(combined_css)
+    combined_css = _EMBED_HOST_STYLE_RESET + combined_css
+
+    if selector:
+        try:
+            matches = soup.select(selector)
+        except Exception as exc:
+            return _embed_error(f"invalid selector '{selector}': {exc}")
+        if not matches:
+            return _embed_error(f"no elements in '{src}' matched selector '{selector}'")
+        fragment = "".join(str(m) for m in matches)
+    else:
+        body = soup.body
+        fragment = body.decode_contents() if body else str(soup)
+
+    digest = hashlib.sha256(f"{src}|{selector or ''}".encode()).hexdigest()[:10]
+    scope_class = f"embed-{digest}"
+
+    style_html = ""
+    if combined_css:
+        style_html = f"<style>@scope (.{scope_class}) {{\n{combined_css}\n}}</style>"
+
+    return f'{style_html}<div class="embedded-html {scope_class}">{fragment}</div>'
+
+
+def _make_embed_replacer(filesystem: "FileSystem | None", base_dir: str):
+    """Build a fenced-block replacer that resolves ```stash-embed blocks.
+
+    Dispatches by `type:` (if set) or by `src` extension + content sniffing.
+    Supported types: openapi, html.
+    """
+
+    def _replace(m: re.Match) -> str:
+        body = m.group("body")
+        try:
+            config = _yaml.safe_load(body) or {}
+        except _yaml.YAMLError as exc:
+            return _embed_error(f"invalid YAML: {exc}")
+        if not isinstance(config, dict):
+            return _embed_error("embed config must be a YAML mapping")
+
+        src = config.get("src")
+        if not isinstance(src, str) or not src:
+            return _embed_error("embed requires a 'src' field")
+        if filesystem is None:
+            return _embed_error(f"cannot resolve '{src}': no filesystem in context")
+
+        resolved = _resolve_embed_src(src, base_dir)
+        try:
+            raw = filesystem.read_file(resolved)
+        except (FileNotFoundError, FSFileNotFoundError):
+            return _embed_error(f"source not found: {src}")
+        except Exception as exc:
+            return _embed_error(f"failed to read '{src}': {exc}")
+
+        suffix = PurePosixPath(resolved).suffix.lower()
+        explicit_type = config.get("type")
+        if explicit_type is not None and not isinstance(explicit_type, str):
+            return _embed_error("'type' must be a string")
+
+        embed_type = explicit_type or _infer_embed_type(src, raw, suffix)
+        if embed_type is None:
+            return _embed_error(
+                f"could not determine embed type for '{src}'; "
+                f"set 'type:' explicitly (openapi, html)"
+            )
+
+        if embed_type == "openapi":
+            return _render_openapi_embed(raw, src, suffix, config)
+        if embed_type == "html":
+            return _render_html_embed(raw, src, config)
+        return _embed_error(f"unknown embed type '{embed_type}' (supported: openapi, html)")
+
+    return _replace
+
+
+def _render_markdown(
+    content: str,
+    filesystem: "FileSystem | None" = None,
+    base_dir: str = "",
+) -> tuple[str, str]:
     """Render markdown to HTML with extensions. Returns (html, toc_html).
 
     Raw HTML in markdown is passed through by design — Stash-MCP stores
@@ -536,6 +870,8 @@ def _render_markdown(content: str) -> tuple[str, str]:
     <details>, <img>, and <div> in markdown files are intentionally supported.
     Do not expose the UI to untrusted third-party content.
     """
+    if filesystem is not None:
+        content = _EMBED_FENCE_RE.sub(_make_embed_replacer(filesystem, base_dir), content)
     content = _CSV_FENCE_RE.sub(_csv_fence_replace, content)
     converter = md.Markdown(extensions=[
         "fenced_code",
@@ -989,6 +1325,32 @@ padding-right:16px !important;border-right:1px solid #313244}
 .viewer-csv-inline .csv-table{font-size:12px}
 .viewer-csv-inline .csv-stats{padding:6px 12px;border-top:1px solid #313244;background:#1e1e2e}
 
+/* embedded openapi block inside markdown */
+.embedded-openapi{margin:1.5rem 0;border:1px solid #313244;border-radius:8px;
+background:#181825;overflow:hidden}
+.embedded-openapi .viewer-openapi{padding:18px 22px}
+.embedded-openapi .oas-header{margin-bottom:1rem}
+.embedded-openapi .oas-header h1{font-size:18px}
+/* Defaults match a standalone browser render — light background + dark text.
+   The source's own body styles (via @scope) override these when set, so dark-
+   themed source HTML still renders dark. The point is that neutral source HTML
+   (no body bg/color) doesn't disappear into Stash's dark theme. */
+.embedded-html{margin:1.5rem 0;padding:18px 22px;border:1px solid #313244;
+border-radius:8px;background:#fff;color:#1e1e2e;color-scheme:light;overflow:auto}
+/* Trim outside margins along the last-child chain so neither the source's
+   own stacking margins (e.g. `section { margin-bottom: 2rem }`) nor UA
+   defaults on deep-nested last children (e.g. `<ol>` inside the final
+   section) create dead space at the bottom of the wrapper. Same for the
+   first-child chain at the top. Specificity (0,2,0) and higher beats the
+   source's `:scope <el>` rules (0,1,1). Three levels covers the typical
+   nesting: wrapper > section > ol > li. */
+.embedded-html > *:first-child,
+.embedded-html > *:first-child > *:first-child,
+.embedded-html > *:first-child > *:first-child > *:first-child{margin-top:0}
+.embedded-html > *:last-child,
+.embedded-html > *:last-child > *:last-child,
+.embedded-html > *:last-child > *:last-child > *:last-child{margin-bottom:0}
+
 /* openapi schema viewer */
 .viewer-openapi{padding:24px 32px}
 .oas-header{margin-bottom:2rem}
@@ -1220,16 +1582,43 @@ function _initPanZoom(wrap){
   if(!wrap.firstElementChild)return;
   var child=wrap.firstElementChild;
   var scale=1,tx=0,ty=0,panning=false,px=0,py=0,ptx=0,pty=0;
+  var MIN=0.2,MAX=5;
   child.style.transformOrigin='0 0';
   function apply(){child.style.transform='translate('+tx+'px,'+ty+'px) scale('+scale+')';}
-  wrap.addEventListener('wheel',function(e){
-    e.preventDefault();
-    var f=e.deltaY>0?0.9:1.1;var ns=Math.min(Math.max(scale*f,0.2),5);
+  function zoomAt(cx,cy,factor){
+    var ns=Math.min(Math.max(scale*factor,MIN),MAX);
     var rect=wrap.getBoundingClientRect();
-    var mx=e.clientX-rect.left, my=e.clientY-rect.top;
+    var mx=cx-rect.left, my=cy-rect.top;
     tx=mx-(mx-tx)*(ns/scale); ty=my-(my-ty)*(ns/scale);
     scale=ns; apply();
+  }
+  // Wheel handler:
+  //  - ctrlKey set → trackpad pinch (browser convention) or ctrl+wheel: zoom.
+  //    Uses an exponential curve so pinch tracks the gesture smoothly instead
+  //    of stepping in fixed 10% increments.
+  //  - Otherwise → if we're zoomed in, pan the embed using deltaX/deltaY
+  //    (handles two-finger trackpad pan). At scale=1 we let the wheel pass
+  //    through so the page can scroll normally past the diagram.
+  wrap.addEventListener('wheel',function(e){
+    if(e.ctrlKey){
+      e.preventDefault();
+      zoomAt(e.clientX,e.clientY,Math.exp(-e.deltaY*0.01));
+      return;
+    }
+    if(scale>1.001){
+      e.preventDefault();
+      tx-=e.deltaX; ty-=e.deltaY; apply();
+    }
   },{passive:false});
+  // Safari trackpad gesture events — same logic, different API.
+  var gestureScale=1;
+  wrap.addEventListener('gesturestart',function(e){e.preventDefault();gestureScale=scale;});
+  wrap.addEventListener('gesturechange',function(e){
+    e.preventDefault();
+    var ns=Math.min(Math.max(gestureScale*e.scale,MIN),MAX);
+    zoomAt(e.clientX,e.clientY,ns/scale);
+  });
+  wrap.addEventListener('gestureend',function(e){e.preventDefault();});
   wrap.addEventListener('mousedown',function(e){
     if(e.target.closest('a'))return;
     panning=true;px=e.clientX;py=e.clientY;ptx=tx;pty=ty;
@@ -1241,6 +1630,37 @@ function _initPanZoom(wrap){
   });
   document.addEventListener('mouseup',function(){
     if(panning){panning=false;wrap.style.cursor='grab';}
+  });
+  // Touch handlers for actual touchscreens (iPad, hybrid laptops). One finger
+  // pans; two fingers pinch-zoom around the midpoint.
+  var t1=null,t2=null,touchStartDist=0,touchStartScale=1,touchStartMid=null;
+  function dist(a,b){var dx=a.clientX-b.clientX,dy=a.clientY-b.clientY;return Math.hypot(dx,dy);}
+  function mid(a,b){return{x:(a.clientX+b.clientX)/2,y:(a.clientY+b.clientY)/2};}
+  wrap.addEventListener('touchstart',function(e){
+    if(e.touches.length===1){
+      t1=e.touches[0];t2=null;
+      px=t1.clientX;py=t1.clientY;ptx=tx;pty=ty;panning=true;
+    }else if(e.touches.length===2){
+      panning=false;
+      t1=e.touches[0];t2=e.touches[1];
+      touchStartDist=dist(t1,t2);touchStartScale=scale;touchStartMid=mid(t1,t2);
+    }
+    if(e.touches.length>0)e.preventDefault();
+  },{passive:false});
+  wrap.addEventListener('touchmove',function(e){
+    if(e.touches.length===1&&panning){
+      e.preventDefault();
+      tx=ptx+(e.touches[0].clientX-px);ty=pty+(e.touches[0].clientY-py);apply();
+    }else if(e.touches.length===2&&touchStartDist>0){
+      e.preventDefault();
+      var d=dist(e.touches[0],e.touches[1]);
+      var ns=Math.min(Math.max(touchStartScale*(d/touchStartDist),MIN),MAX);
+      zoomAt(touchStartMid.x,touchStartMid.y,ns/scale);
+    }
+  },{passive:false});
+  wrap.addEventListener('touchend',function(e){
+    if(e.touches.length<2){touchStartDist=0;}
+    if(e.touches.length===0){panning=false;}
   });
   wrap.style.cursor='grab';
   wrap.style.overflow='hidden';
@@ -1274,7 +1694,7 @@ if(typeof mermaid!=='undefined'){
       _initPanZoom(el);
       var hint=document.createElement('span');
       hint.className='mermaid-hint';
-      hint.textContent='Scroll to zoom · Drag to pan';
+      hint.textContent='Pinch or ⌃scroll to zoom · Drag to pan';
       el.appendChild(hint);
     });
   });
@@ -1378,11 +1798,11 @@ def _page(
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{html.escape(title)} – Stash-MCP</title>
 <style>{_CSS}</style>
-<link rel="stylesheet" href="/static/vendor/github-dark.min.css">
-<script src="/static/vendor/highlight.min.js"></script>
-<script src="/static/vendor/languages/terraform.min.js"></script>
-<script src="/static/vendor/mermaid.min.js"></script>
-<script src="/static/vendor/stash-gantt.js"></script>
+<link rel="stylesheet" href="{_static_url("vendor/github-dark.min.css")}">
+<script src="{_static_url("vendor/highlight.min.js")}"></script>
+<script src="{_static_url("vendor/languages/terraform.min.js")}"></script>
+<script src="{_static_url("vendor/mermaid.min.js")}"></script>
+<script src="{_static_url("vendor/stash-gantt.js")}"></script>
 </head>
 <body>
 <div class="app">
@@ -1627,10 +2047,10 @@ def create_ui_router(
                         f'<div class="viewer-content"><pre>{escaped_content}</pre></div>'
                     )
             elif path.endswith((".md", ".markdown")):
-                rendered, toc_html = _render_markdown(content)
                 base_dir = str(PurePosixPath(path).parent)
                 if base_dir == ".":
                     base_dir = ""
+                rendered, toc_html = _render_markdown(content, filesystem, base_dir)
                 rendered = _rewrite_relative_urls(rendered, base_dir)
                 center = (
                     f'<div class="viewer-content markdown-body">{rendered}</div>'

--- a/stash_mcp/ui.py
+++ b/stash_mcp/ui.py
@@ -17,7 +17,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from .events import CONTENT_CREATED, CONTENT_DELETED, CONTENT_MOVED, CONTENT_UPDATED, emit
 from .filesystem import FileNotFoundError as FSFileNotFoundError
-from .filesystem import FileSystem
+from .filesystem import FileSystem, InvalidPathError
 from .mcp_server import MIME_TYPES
 
 _STATIC_DIR = Path(__file__).parent / "static"
@@ -1014,6 +1014,11 @@ def _make_embed_replacer(filesystem: "FileSystem | None", base_dir: str):
             raw = filesystem.read_file(resolved)
         except (FileNotFoundError, FSFileNotFoundError):
             return _embed_error(f"source not found: {src}")
+        except InvalidPathError:
+            # `..` escapes or absolute paths that resolve outside the content
+            # root reach here. Surface a dedicated message rather than leaking
+            # the raw exception text via the generic handler below.
+            return _embed_error(f"invalid src '{src}': resolves outside content directory")
         except Exception as exc:
             return _embed_error(f"failed to read '{src}': {exc}")
 

--- a/stash_mcp/ui.py
+++ b/stash_mcp/ui.py
@@ -2,10 +2,12 @@
 
 import base64
 import csv
+import functools
 import html
 import io
 import json as _json
 import logging
+import posixpath
 import re
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
@@ -23,12 +25,19 @@ from .mcp_server import MIME_TYPES
 _STATIC_DIR = Path(__file__).parent / "static"
 
 
+@functools.lru_cache(maxsize=128)
 def _static_url(rel_path: str) -> str:
     """Return a `/static/...` URL with an mtime-based cache buster.
 
     Browsers cache `/static/*` aggressively. Appending the file's mtime as a
     query string means any edit to a shipped asset invalidates the cache on
     next page load — no hard-refresh required.
+
+    The mtime is read once per asset per process via `lru_cache` — the shipped
+    static files don't change at runtime (they're packaged with the install),
+    so a single `stat()` at first reference is enough. Editing an asset
+    requires a process restart to be reflected, which matches deployment
+    expectations and keeps page renders off the filesystem.
     """
     try:
         mtime = int((_STATIC_DIR / rel_path).stat().st_mtime)
@@ -561,12 +570,25 @@ def _resolve_embed_src(src: str, base_dir: str) -> str:
 
     Absolute (`/specs/api.json`) is rooted at the content store; otherwise the
     src is interpreted relative to the embedding document's directory.
+
+    The result is normalized (`.`/`..` segments collapsed) so downstream
+    consumers — `filesystem.read_file`, embed-error messages, and the URL
+    rewriter that uses the parent dir to anchor relative `<img>`/`<a>`
+    targets — get a clean path. A `src` that escapes the content root with
+    leading `..` segments still yields a path starting with `..`, which the
+    filesystem layer rejects with `InvalidPathError`; the caller catches that
+    and produces a dedicated embed error.
     """
     if src.startswith("/"):
-        return src.lstrip("/")
-    if base_dir:
-        return str(PurePosixPath(base_dir) / src)
-    return src
+        joined = src.lstrip("/")
+    elif base_dir:
+        joined = str(PurePosixPath(base_dir) / src)
+    else:
+        joined = src
+    normalized = posixpath.normpath(joined) if joined else ""
+    # normpath("") -> "." — collapse that to "" so callers see "no path"
+    # consistently when the input was empty.
+    return "" if normalized == "." else normalized
 
 
 def _filter_openapi_spec(

--- a/stash_mcp/ui.py
+++ b/stash_mcp/ui.py
@@ -742,6 +742,64 @@ def _extract_keyframes(css: str) -> tuple[str, dict[str, str]]:
     return "".join(out), placeholders
 
 
+def _split_top_level_commas(s: str) -> list[str]:
+    """Split `s` on commas that sit at the top level — outside parentheses,
+    square brackets, and quoted strings.
+
+    Needed for CSS selector lists: `:is(h1, h2, h3) { ... }` is a single
+    selector, but a naive `s.split(",")` would shred it into three nonsense
+    fragments (`:is(h1`, `h2`, `h3)`). Functional pseudo-classes like
+    `:is()`, `:not()`, `:where()`, `:has()`, and `:nth-child(2n+1 of ...)`
+    all rely on this behavior, and attribute selectors like `[data-x=","]`
+    can carry a literal comma inside brackets/strings too.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    paren = 0
+    bracket = 0
+    in_string: str | None = None
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if in_string is not None:
+            buf.append(ch)
+            if ch == "\\" and i + 1 < len(s):
+                # Pass through escape sequence atomically so an escaped quote
+                # doesn't end the string.
+                buf.append(s[i + 1])
+                i += 2
+                continue
+            if ch == in_string:
+                in_string = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_string = ch
+            buf.append(ch)
+        elif ch == "(":
+            paren += 1
+            buf.append(ch)
+        elif ch == ")":
+            if paren > 0:
+                paren -= 1
+            buf.append(ch)
+        elif ch == "[":
+            bracket += 1
+            buf.append(ch)
+        elif ch == "]":
+            if bracket > 0:
+                bracket -= 1
+            buf.append(ch)
+        elif ch == "," and paren == 0 and bracket == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
 def _scope_css_selectors(css: str) -> str:
     """Rewrite every non-@-rule selector in `css` so it gains class-level
     specificity inside the embed's `@scope (.embed-xxx)` block.
@@ -755,6 +813,9 @@ def _scope_css_selectors(css: str) -> str:
 
     `@keyframes` blocks are extracted first and spliced back unchanged so we
     don't try to rewrite their step lists (`0%`, `from`, `to`) as selectors.
+    Selector lists are split with `_split_top_level_commas` so commas inside
+    `:is(...)` / `:not(...)` / attribute selectors don't shred a functional
+    pseudo-class into garbage.
     """
     css, keyframes = _extract_keyframes(css)
 
@@ -764,7 +825,7 @@ def _scope_css_selectors(css: str) -> str:
         if not selectors.strip():
             return match.group(0)
         parts: list[str] = []
-        for raw in selectors.split(","):
+        for raw in _split_top_level_commas(selectors):
             stripped = raw.strip()
             if not stripped:
                 continue

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -398,6 +398,25 @@ class TestUIEmbed:
         assert "Embed error" in body
         assert "src" in body and "field" in body
 
+    def test_embed_src_escaping_content_root_shows_dedicated_error(self):
+        """A `src` containing `..` segments that escape the content root must
+        produce a clean embed error, not leak the raw `InvalidPathError`
+        message through the generic exception handler."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "plans/escape.md",
+                "```stash-embed\nsrc: ../../etc/passwd\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/plans/escape.md").text
+
+        assert "Embed error" in body
+        assert "outside content directory" in body
+        # The generic handler's phrasing must NOT surface here.
+        assert "failed to read" not in body
+
 
 _SAMPLE_HTML = """<!DOCTYPE html>
 <html>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -279,6 +279,392 @@ class TestUIMarkdown:
         assert "Some content here." in body
 
 
+_SAMPLE_OPENAPI = """{
+  "openapi": "3.0.0",
+  "info": {"title": "Orders API", "version": "1.0.0"},
+  "paths": {
+    "/orders": {
+      "get": {"tags": ["orders"], "summary": "List orders",
+              "operationId": "listOrders", "responses": {"200": {"description": "OK"}}},
+      "post": {"tags": ["orders"], "summary": "Create order",
+               "operationId": "createOrder", "responses": {"201": {"description": "Created"}}}
+    },
+    "/health": {
+      "get": {"tags": ["health"], "summary": "Healthcheck",
+              "operationId": "health", "responses": {"200": {"description": "OK"}}}
+    }
+  },
+  "components": {"schemas": {"Order": {"type": "object"}}}
+}
+"""
+
+
+@pytest.fixture
+def embed_client():
+    """UI client with an OpenAPI spec and markdown documents that embed it."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        fs.write_file("specs/orders.json", _SAMPLE_OPENAPI)
+        fs.write_file(
+            "plans/q2.md",
+            "# Q2 Plan\n\n"
+            "```stash-embed\n"
+            "src: /specs/orders.json\n"
+            "tag: orders\n"
+            "```\n\n"
+            "More notes.\n",
+        )
+        fs.write_file(
+            "plans/relative.md",
+            "```stash-embed\n"
+            "src: ../specs/orders.json\n"
+            "path: /health\n"
+            "```\n",
+        )
+        fs.write_file(
+            "plans/missing.md",
+            "```stash-embed\nsrc: specs/nope.json\n```\n",
+        )
+        fs.write_file(
+            "plans/notapi.md",
+            "```stash-embed\nsrc: /plans/q2.md\n```\n",
+        )
+        fs.write_file(
+            "plans/nomatch.md",
+            "```stash-embed\nsrc: /specs/orders.json\ntag: ghost\n```\n",
+        )
+        fs.write_file(
+            "plans/badyaml.md",
+            "```stash-embed\nsrc: /specs/orders.json\n  tag: : :\n  - bad\n```\n",
+        )
+        fs.write_file(
+            "plans/nosrc.md",
+            "```stash-embed\ntag: orders\n```\n",
+        )
+
+        app = create_api(fs)
+        router = create_ui_router(fs)
+        app.include_router(router)
+        yield TestClient(app)
+
+
+class TestUIEmbed:
+    """Tests for ```stash-embed``` OpenAPI fragment embedding."""
+
+    def test_embed_by_tag_renders_inline_openapi(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/q2.md").text
+        assert "embedded-openapi" in body
+        assert "Orders API</h1>" in body
+        # Surrounding markdown is preserved.
+        assert "Q2 Plan</h1>" in body
+        assert "More notes." in body
+        # Tag filter kept orders operations and excluded health.
+        assert "List orders" in body
+        assert "Create order" in body
+        assert "Healthcheck" not in body
+        # Filtered embeds drop the schemas block.
+        assert "SCHEMA" not in body
+
+    def test_embed_resolves_relative_src(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/relative.md").text
+        assert "embedded-openapi" in body
+        # path filter kept only /health.
+        assert "Healthcheck" in body
+        assert "List orders" not in body
+        assert "Create order" not in body
+
+    def test_embed_missing_source_shows_error(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/missing.md").text
+        assert "Embed error" in body
+        assert "source not found" in body
+
+    def test_embed_non_openapi_source_shows_error(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/notapi.md").text
+        assert "Embed error" in body
+        # The dispatcher can't infer a type from a markdown source.
+        assert "could not determine embed type" in body
+
+    def test_embed_no_matches_shows_error(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/nomatch.md").text
+        assert "Embed error" in body
+        assert "no operations" in body
+
+    def test_embed_invalid_yaml_shows_error(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/badyaml.md").text
+        assert "Embed error" in body
+
+    def test_embed_missing_src_shows_error(self, embed_client):
+        body = embed_client.get("/ui/browse/plans/nosrc.md").text
+        assert "Embed error" in body
+        assert "src" in body and "field" in body
+
+
+_SAMPLE_HTML = """<!DOCTYPE html>
+<html>
+<head><title>Q2 Report</title></head>
+<body>
+<section id="summary"><h2>Summary</h2><p>Things are on track.</p></section>
+<section id="risks" class="callout"><h2>Risks</h2>
+<ul><li>backfill throughput</li><li>region drift</li></ul></section>
+<section id="links"><a href="/internal">internal</a></section>
+</body>
+</html>
+"""
+
+
+@pytest.fixture
+def html_embed_client():
+    """UI client with an HTML doc and markdown that embeds slices of it."""
+    with TemporaryDirectory() as tmpdir:
+        fs = FileSystem(Path(tmpdir))
+        fs.write_file("reports/q2.html", _SAMPLE_HTML)
+        fs.write_file(
+            "plans/with_selector.md",
+            "# Plan\n\n"
+            "```stash-embed\n"
+            "src: /reports/q2.html\n"
+            "selector: \"#risks\"\n"
+            "```\n",
+        )
+        fs.write_file(
+            "plans/no_selector.md",
+            "```stash-embed\nsrc: /reports/q2.html\n```\n",
+        )
+        fs.write_file(
+            "plans/no_match.md",
+            "```stash-embed\nsrc: /reports/q2.html\nselector: \"#ghost\"\n```\n",
+        )
+        fs.write_file(
+            "plans/class_selector.md",
+            "```stash-embed\nsrc: /reports/q2.html\nselector: \".callout li\"\n```\n",
+        )
+        # Force a non-html-extension file to be treated as html via the override.
+        fs.write_file("snippets/raw.txt", "<div id=\"note\">forced</div>")
+        fs.write_file(
+            "plans/type_override.md",
+            "```stash-embed\n"
+            "src: /snippets/raw.txt\n"
+            "type: html\n"
+            "selector: \"#note\"\n"
+            "```\n",
+        )
+        # Ambiguous file (plain .txt) without an override should error.
+        fs.write_file("snippets/plain.txt", "just some text")
+        fs.write_file(
+            "plans/ambiguous.md",
+            "```stash-embed\nsrc: /snippets/plain.txt\n```\n",
+        )
+
+        app = create_api(fs)
+        router = create_ui_router(fs)
+        app.include_router(router)
+        yield TestClient(app)
+
+
+class TestUIEmbedHTML:
+    """Tests for HTML fragment embedding via ```stash-embed```."""
+
+    def test_embed_html_by_id_selector(self, html_embed_client):
+        body = html_embed_client.get("/ui/browse/plans/with_selector.md").text
+        assert "embedded-html" in body
+        # Selector kept #risks and its contents.
+        assert "Risks</h2>" in body
+        assert "backfill throughput" in body
+        # Other sections were excluded.
+        assert "Summary</h2>" not in body
+        assert "Things are on track" not in body
+
+    def test_embed_html_compound_selector(self, html_embed_client):
+        body = html_embed_client.get("/ui/browse/plans/class_selector.md").text
+        assert "embedded-html" in body
+        assert "backfill throughput" in body
+        assert "region drift" in body
+        # Headings outside the selector are gone.
+        assert "Risks</h2>" not in body
+
+    def test_embed_html_without_selector_returns_body(self, html_embed_client):
+        import re as _re
+        body = html_embed_client.get("/ui/browse/plans/no_selector.md").text
+        match = _re.search(
+            r'<div class="embedded-html[^"]*">(.*?)</div>\s*<', body, _re.DOTALL,
+        )
+        assert match, "embedded-html block not found"
+        embed_inner = match.group(1)
+        # All three sections present when no selector filters them.
+        assert "Summary</h2>" in embed_inner
+        assert "Risks</h2>" in embed_inner
+        # We return body's *contents*, not the <body> tag itself.
+        assert "<body" not in embed_inner
+
+    def test_embed_html_no_match_shows_error(self, html_embed_client):
+        body = html_embed_client.get("/ui/browse/plans/no_match.md").text
+        assert "Embed error" in body
+        assert "no elements" in body
+        assert "#ghost" in body
+
+    def test_embed_type_override_forces_html(self, html_embed_client):
+        body = html_embed_client.get("/ui/browse/plans/type_override.md").text
+        assert "embedded-html" in body
+        assert "forced" in body
+
+    def test_embed_ambiguous_src_without_type_errors(self, html_embed_client):
+        body = html_embed_client.get("/ui/browse/plans/ambiguous.md").text
+        assert "Embed error" in body
+        assert "could not determine embed type" in body
+
+    def test_embed_html_rewrites_root_selectors_to_scope(self):
+        """`body { color }` in the source should become `:scope { color }` so
+        it applies to the embed wrapper, not to a (nonexistent) <body> inside
+        the embed. Other selectors also get a `:scope ` prefix to gain
+        class-level specificity (see test_embed_html_boosts_selector_specificity)."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<!DOCTYPE html><html><head>"
+                "<style>"
+                "body { color: #1e1e2e; font-family: serif; }"
+                "html, body { margin: 0; }"
+                ":root { --accent: red; }"
+                ".body-text { color: blue; }"
+                "p body { not-a-real-rule: 1; }"
+                "</style></head><body>"
+                "<section id=\"a\">hi</section>"
+                "</body></html>",
+            )
+            fs.write_file("host.md", "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n")
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # Root selectors got rewritten to :scope.
+        assert ":scope { color: #1e1e2e; font-family: serif; }" in body
+        assert ":scope, :scope { margin: 0; }" in body
+        assert ":scope { --accent: red; }" in body
+        # Non-root selectors get the specificity-boost prefix; the `body`
+        # substring inside class names and non-leading positions is preserved.
+        assert ":scope .body-text { color: blue; }" in body
+        assert ":scope p body { not-a-real-rule: 1; }" in body
+
+    def test_embed_html_emits_host_style_reset(self):
+        """A reset block forces text-bearing elements to revert host styles so
+        rules like `.markdown-body th { background }` and `.markdown-body code
+        { background }` don't bleed into the embed. The reset uses `all: revert`
+        with specificity (0,1,1) — ties host's `.markdown-body <el>` rules and
+        wins by source order. Source class rules (0,2,0+) still override it."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<head><style>body { color: green; } h2 { margin-top: 0; } "
+                ".metric { color: red; }</style></head>"
+                "<body><section id=\"a\"><h2>x</h2></section></body>",
+            )
+            fs.write_file("host.md", "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n")
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # Reset is present and uses `all: revert`.
+        reset_idx = body.find(":scope h1, :scope h2")
+        source_h2_idx = body.find(":scope h2 { margin-top: 0; }")
+        source_root_idx = body.find(":scope { color: green; }")
+        assert reset_idx >= 0
+        assert "all: revert" in body
+        # Reset comes before the source's own rules so source wins by order.
+        assert source_h2_idx > reset_idx
+        assert source_root_idx > reset_idx
+        # The reset covers common host-bleed elements: headings, lists, tables,
+        # code blocks, inline emphasis.
+        for token in ["h1", "h2", "h3", "p", "a", "li", "th", "td",
+                      "blockquote", "code", "pre", "strong"]:
+            assert f":scope {token}" in body
+
+    def test_embed_html_emits_reset_even_without_source_styles(self):
+        """A source with no <style> block still needs the reset so host
+        markdown rules like `.markdown-body code { background: #181825 }`
+        don't leak through to bare HTML snippets."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "snippet.html",
+                "<div id=\"note\">Use <code>x</code> here.</div>",
+            )
+            fs.write_file(
+                "host.md",
+                "```stash-embed\nsrc: /snippet.html\nselector: \"#note\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # Even with no <style> in the source, the @scope block + reset is emitted.
+        assert "<style>@scope (.embed-" in body
+        assert "all: revert" in body
+        assert ":scope code" in body
+
+    def test_embed_html_boosts_selector_specificity(self):
+        """Every non-root selector gets a `:scope ` prefix so source rules tie
+        with host rules like `.markdown-body h2 { color: ... }` and win on
+        source order. Without this, naked `h2 { ... }` in the source has
+        specificity (0,0,1) and loses to the host's (0,1,1)."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<head><style>"
+                "h2 { color: green; }"
+                "section.callout { background: yellow; }"
+                ".metric { font-weight: 700; }"
+                "</style></head><body>"
+                "<section id=\"a\" class=\"callout\"><h2>hi</h2></section>"
+                "</body>",
+            )
+            fs.write_file("host.md", "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n")
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        assert ":scope h2 { color: green; }" in body
+        assert ":scope section.callout { background: yellow; }" in body
+        assert ":scope .metric { font-weight: 700; }" in body
+
+    def test_embed_html_styled_source(self):
+        """Standalone test: source with <style> emits a scoped @scope block."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<!DOCTYPE html><html><head>"
+                "<style>section { border-left: 3px solid red; } "
+                ".callout { background: yellow; }</style>"
+                "</head><body>"
+                "<section id=\"a\" class=\"callout\">hello</section>"
+                "</body></html>",
+            )
+            fs.write_file(
+                "host.md",
+                "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # The fragment is present.
+        assert "hello" in body
+        # The source's <style> rules were copied across, with :scope prefix.
+        assert ":scope section { border-left: 3px solid red" in body
+        assert ":scope .callout { background: yellow" in body
+        # And they were wrapped in an @scope rule keyed to this embed.
+        assert "@scope (.embed-" in body
+        # The fragment carries the matching scope class on its wrapper.
+        import re as _re
+        scope_match = _re.search(r"@scope \(\.(embed-[a-f0-9]+)\)", body)
+        assert scope_match
+        scope_class = scope_match.group(1)
+        assert f'class="embedded-html {scope_class}"' in body
+
+
 class TestUISearch:
     """Tests for sidebar search functionality."""
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -398,6 +398,47 @@ class TestUIEmbed:
         assert "Embed error" in body
         assert "src" in body and "field" in body
 
+    def test_embed_src_with_dotdot_segments_is_normalized(self):
+        """A `src` with `..` segments that stays inside the content root should
+        normalize cleanly — no `/ui/raw/plans/../reports/...`-style URLs end
+        up in the rendered output (brittle for caches and path-based
+        middleware)."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "reports/q2.html",
+                "<body><div id=\"a\"><img src=\"images/foo.png\"></div></body>",
+            )
+            fs.write_file(
+                "plans/draft.md",
+                # `../reports/q2.html` from plans/ resolves to reports/q2.html
+                # — the `..` should be collapsed before any URL is emitted.
+                "```stash-embed\nsrc: ../reports/q2.html\nselector: \"#a\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/plans/draft.md").text
+
+        # Resolved URL is clean — no `..` segment leaks through.
+        assert 'src="/ui/raw/reports/images/foo.png"' in body
+        assert ".." not in body.split("embedded-html")[1].split("</div>")[0]
+
+    def test_static_url_caches_mtime(self):
+        """`_static_url` should stat each asset at most once per process —
+        otherwise every page render does N filesystem hits for the vendor JS."""
+        import stash_mcp.ui as ui_mod
+        # Clear cache so we start from a known state.
+        ui_mod._static_url.cache_clear()
+        url1 = ui_mod._static_url("vendor/stash-gantt.js")
+        info1 = ui_mod._static_url.cache_info()
+        # Second call must be a cache hit (no new miss).
+        url2 = ui_mod._static_url("vendor/stash-gantt.js")
+        info2 = ui_mod._static_url.cache_info()
+        assert url1 == url2
+        assert info1.misses == 1
+        assert info2.misses == 1
+        assert info2.hits >= 1
+
     def test_embed_src_escaping_content_root_shows_dedicated_error(self):
         """A `src` containing `..` segments that escape the content root must
         produce a clean embed error, not leak the raw `InvalidPathError`

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -664,6 +664,42 @@ class TestUIEmbedHTML:
         scope_class = scope_match.group(1)
         assert f'class="embedded-html {scope_class}"' in body
 
+    def test_embed_html_preserves_functional_pseudo_classes(self):
+        """Selector lists inside `:is(...)`, `:not(...)`, `:where(...)`,
+        `[attr="a,b"]` etc. must NOT be split on their inner commas. A naive
+        `s.split(",")` would shred `:is(h1, h2)` into `:is(h1` and `h2)`,
+        producing invalid CSS."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<head><style>"
+                ":is(h1, h2, h3) { color: green; }"
+                ":not(.x, .y) { padding: 0; }"
+                ":where(article, section) p { line-height: 1.5; }"
+                "[data-tag=\"a,b\"] { display: none; }"
+                "li:nth-child(2n+1 of .ok, .also-ok) { background: blue; }"
+                "</style></head>"
+                "<body><section id=\"a\">hi</section></body>",
+            )
+            fs.write_file(
+                "host.md",
+                "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # Inner commas preserved; functional pseudo-classes not fractured.
+        assert ":scope :is(h1, h2, h3) { color: green; }" in body
+        assert ":scope :not(.x, .y) { padding: 0; }" in body
+        assert ":scope :where(article, section) p { line-height: 1.5; }" in body
+        assert ':scope [data-tag="a,b"] { display: none; }' in body
+        assert ":scope li:nth-child(2n+1 of .ok, .also-ok) { background: blue; }" in body
+        # Negative checks: no fragments from a bad comma split.
+        assert ":scope h2, h3)" not in body
+        assert ":scope .y)" not in body
+
     def test_embed_html_preserves_keyframes(self):
         """`@keyframes` step lists (`0%`, `from`, `to`) are NOT CSS selectors —
         they must not be prefixed with `:scope` or the animation breaks."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -664,6 +664,153 @@ class TestUIEmbedHTML:
         scope_class = scope_match.group(1)
         assert f'class="embedded-html {scope_class}"' in body
 
+    def test_embed_html_preserves_keyframes(self):
+        """`@keyframes` step lists (`0%`, `from`, `to`) are NOT CSS selectors —
+        they must not be prefixed with `:scope` or the animation breaks."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<head><style>"
+                "@keyframes fade { 0% { opacity: 0; } 100% { opacity: 1; } }"
+                "@-webkit-keyframes slide { from { left: 0; } to { left: 10px; } }"
+                ".box { animation: fade 1s; }"
+                "</style></head>"
+                "<body><section id=\"a\"><div class=\"box\">hi</div></section></body>",
+            )
+            fs.write_file(
+                "host.md",
+                "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # Keyframe step lists pass through unchanged — no `:scope` prefix
+        # injected into `0%`, `100%`, `from`, `to`.
+        assert "0% { opacity: 0; }" in body
+        assert "100% { opacity: 1; }" in body
+        assert "from { left: 0; }" in body
+        assert "to { left: 10px; }" in body
+        assert ":scope 0%" not in body
+        assert ":scope from " not in body
+        assert ":scope to " not in body
+        # The keyframes at-rule prelude itself is also intact.
+        assert "@keyframes fade" in body
+        assert "@-webkit-keyframes slide" in body
+        # Non-keyframe selectors still get scoped.
+        assert ":scope .box" in body
+
+    def test_embed_html_strips_scripts(self):
+        """`<script>` elements and `on*` event handlers from embedded HTML are
+        stripped so they can't execute in the host document's origin (standalone
+        `.html` views run in a sandboxed iframe; embeds inject directly)."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "src.html",
+                "<body>"
+                "<script>window.pwned = 1;</script>"
+                "<div id=\"a\" onclick=\"alert(1)\" onmouseover=\"x()\">"
+                "<a href=\"javascript:alert(2)\">bad</a>"
+                "<a href=\"/safe\">good</a>"
+                "</div></body>",
+            )
+            fs.write_file(
+                "host.md",
+                "```stash-embed\nsrc: /src.html\nselector: \"#a\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/host.md").text
+
+        # Isolate the embed wrapper — the host UI has its own onclick handlers
+        # on sidebar buttons, so we can't assert against the whole page.
+        import re as _re
+        m = _re.search(r'<div class="embedded-html[^"]*">(.*?)</div>', body, _re.DOTALL)
+        assert m, "embedded-html wrapper not found"
+        embed = m.group(1)
+
+        # No <script>, no event handler attrs, no javascript: URL.
+        assert "window.pwned" not in body
+        assert "<script" not in embed
+        assert "onclick" not in embed
+        assert "onmouseover" not in embed
+        assert "javascript:alert" not in embed
+        # But the safe link and surrounding content are kept.
+        assert 'href="/safe"' in embed
+        assert ">good<" in embed
+
+    def test_embed_html_rewrites_relative_urls_to_source_dir(self):
+        """Relative `src`/`href` inside an embedded fragment must resolve
+        relative to the *source HTML's* directory, not the embedding markdown's
+        directory. Otherwise `<img src="images/foo.png">` in `reports/q2.html`
+        embedded from `plans/draft.md` points at `/ui/raw/plans/images/foo.png`."""
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            fs.write_file(
+                "reports/q2.html",
+                "<body><div id=\"a\">"
+                "<img src=\"images/foo.png\">"
+                "<a href=\"sibling.html\">sib</a>"
+                "</div></body>",
+            )
+            fs.write_file(
+                "plans/draft.md",
+                "```stash-embed\nsrc: /reports/q2.html\nselector: \"#a\"\n```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/plans/draft.md").text
+
+        # img src rewritten under reports/, not plans/.
+        assert 'src="/ui/raw/reports/images/foo.png"' in body
+        assert "/ui/raw/plans/images/" not in body
+        # anchor href rewritten under reports/ via /ui/browse/.
+        assert 'href="/ui/browse/reports/sibling.html"' in body
+
+
+class TestUIEmbedOpenAPIYamlOverride:
+    """Edge case: `type: openapi` with a YAML spec under a non-yaml extension."""
+
+    def test_openapi_yaml_under_txt_with_explicit_type(self):
+        """YAML 1.1 parses JSON as a subset, so a single `yaml.safe_load` should
+        handle openapi specs regardless of file extension when the user sets
+        `type: openapi` explicitly."""
+        yaml_spec = (
+            "openapi: 3.0.0\n"
+            "info:\n"
+            "  title: X\n"
+            "  version: '1.0'\n"
+            "paths:\n"
+            "  /things:\n"
+            "    get:\n"
+            "      operationId: listThings\n"
+            "      responses:\n"
+            "        '200':\n"
+            "          description: OK\n"
+        )
+        with TemporaryDirectory() as tmpdir:
+            fs = FileSystem(Path(tmpdir))
+            # Stored under .txt — `_infer_embed_type` would not pick this up
+            # automatically; the user must override with `type: openapi`.
+            fs.write_file("specs/things.txt", yaml_spec)
+            fs.write_file(
+                "plans/use.md",
+                "```stash-embed\n"
+                "src: /specs/things.txt\n"
+                "type: openapi\n"
+                "```\n",
+            )
+            app = create_api(fs)
+            app.include_router(create_ui_router(fs))
+            body = TestClient(app).get("/ui/browse/plans/use.md").text
+
+        # Parsed correctly: operation appears in the embed.
+        assert "Embed error" not in body
+        assert "listThings" in body
+        assert "embedded-openapi" in body
+
 
 class TestUISearch:
     """Tests for sidebar search functionality."""

--- a/uv.lock
+++ b/uv.lock
@@ -83,6 +83,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -648,6 +661,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -660,6 +674,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -668,6 +683,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2375,6 +2391,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2405,11 +2430,13 @@ name = "stash-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "markdown" },
     { name = "pydantic" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "tinyflux" },
     { name = "uvicorn" },
 ]
@@ -2446,6 +2473,7 @@ search-openai = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'search-contextual'", specifier = ">=0.40.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
@@ -2465,6 +2493,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "tiktoken", marker = "extra == 'search-openai'", specifier = "==0.12.0" },
     { name = "tinyflux", specifier = ">=1.2.0" },
@@ -2608,6 +2637,11 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
## Summary

Adds a ```` ```stash-embed ```` YAML-fenced block that renders a slice of another document inline in a markdown host. The source stays the single source of truth — edits there propagate everywhere the embed appears, no duplication.

````markdown
```stash-embed
src: /specs/orders.json
tag: orders
```

```stash-embed
src: /reports/q1.html
selector: "#metrics"
```
````

## What's in the box

**Dispatcher.** Reads `src`, infers type from the extension + content sniff, honors an explicit `type:` override. Two types supported today: `openapi` (filtered by `tag`, `path`, or `operationId`; AND semantics) and `html` (filtered by any CSS selector via BeautifulSoup; no selector returns `<body>` contents).

**HTML style isolation.** Source `<style>` blocks get extracted, rewritten, and wrapped in CSS `@scope` keyed to a per-embed hash class:

- Root selectors (`body`, `html`, `:root`) → `:scope`, so author body styling lands on the wrapper.
- Every other selector gets a `:scope ` prefix to gain class-level specificity, so source rules can win ties against host rules like `.markdown-body h2 { color }` on source order.
- A defensive `all: revert` reset on common text-bearing elements (h1–h6, p, a, li, ul/ol, table cells, code/pre, blockquote, etc.) neutralizes host bleed even when the source ships no `<style>` block at all (e.g. a bare `.txt` snippet forced through `type: html`).
- Wrapper defaults to white-on-dark-text + `color-scheme: light` so neutral source HTML doesn't disappear into Stash's dark theme.
- Last-child margins zeroed three levels deep so deep-nested UA-default margins (e.g. `<ol>` inside the final `<section>`) don't create dead space at the wrapper bottom.

**Browser support.** Requires `@scope`-aware browsers (Chrome/Edge 118+, Safari 17.4+, Firefox 128+ — all ~2 years stable).

**Errors render inline.** Missing `src`, source not found, no-match selector, ambiguous source type, invalid selector — every failure path renders an `.error-msg` block instead of silently dropping content or crashing.

## Drive-by improvements

- **Static asset cache buster** — `/static/*` URLs gain `?v=<mtime>` so JS/CSS edits invalidate the browser cache on next page load. No more hard-refresh needed.
- **Mermaid + Gantt panzoom rewrite** — ctrl/pinch zoom with a smooth exponential curve (replacing fixed 10% steps that snapped jarringly on trackpads), Safari `gesturechange` events, two-finger touch pinch for iPad/hybrid laptops, and `grab`/`grabbing` cursors signaling draggability. Plain wheel passes through to the page so two-finger scrolling no longer traps the cursor over a diagram.
- **Gantt clipPath** — bars and dependency arrows now route through an SVG clipPath covering the chart area, so they don't bleed over the label column when zoomed in.
- **Gantt click-anywhere-to-pan** — drag from any point on the chart pans the timeline. `Shift`-drag a bar still reschedules it (non-readonly). Click a bar without dragging still selects it.

## SKILL update

Bumped to 0.1.8. New "Embed-by-reference" section documents shared fields, per-type fields, the `type:` override semantics, `<style>` scoping behavior (including `@keyframes` passthrough), and the `@scope` browser support floor. Document-types table cross-references the embed syntax from the API-specs and Web rows. 0.1.8 also documents the post-review hardening: relative-URL resolution against the source's directory, the strip-on-embed sanitizer (`<script>`, `on*`, `javascript:`), and that `type: openapi` works on any extension because parsing is YAML.

## Test plan

- [x] All 65 UI tests pass locally (`uv run pytest tests/test_ui.py`)
- [x] Verified `@scope` cascade in browser via Playwright against real host CSS — body text inherits source color, headings/tables/code no longer carry host backgrounds, source class rules (`.metric { color: green }`) beat the reset
- [x] Eyeball `/ui/browse/projects/project-plan.md` — `## API Schema` section should render the orders OpenAPI tag inline
- [x] Eyeball `/ui/browse/projects/q2-kickoff.md` — multi-source slices: id selector (`#summary`), class selector (`section.win`), compound selector, full-body no-selector, plus an OpenAPI `operationId` embed
- [x] Eyeball `/ui/browse/projects/embed-showcase.md` — all 9 happy paths + 8 error cases (missing src, file not found, no-match selector, no-match filter, ambiguous type, unknown type, malformed YAML, invalid selector)
- [x] Mermaid + Gantt zoom/pan behavior on a MacBook trackpad: pinch zooms smoothly, two-finger pan no longer traps the page, ctrl+scroll zooms for non-trackpad users
- [x] Gantt clipping when zoomed in — bars stay out of the label column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
