### PR TITLE
docs(search): tighten search_content tool description

### DIFF
--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -921,7 +921,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
 
         @mcp.tool(
             annotations=ToolAnnotations(
-                title="Search content",
+                title="Search content by meaning",
                 readOnlyHint=True,
                 openWorldHint=False,
             )
@@ -932,6 +932,16 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             file_types: str | None = None,
         ) -> str:
             """Search for content by meaning using semantic similarity.
+
+            Best for conceptual or open-ended queries where the most relevant
+            chunks matter even if the exact wording differs — e.g. "how does
+            the transaction system handle rollback", "what's the indexing
+            strategy for embeddings". Returns the top-k ranked results.
+
+            For literal substring or regex matching with exhaustive results
+            (every file mentioning STASH_FOO, every reference to an old
+            symbol, every occurrence of an error string), use find_content
+            instead — it does not rank and does not cap at top-k.
 
             Args:
                 query: Natural language search query


### PR DESCRIPTION
## Summary

- Updates `ToolAnnotations.title` from `"Search content"` to `"Search content by meaning"`.
- Expands the `search_content` docstring to clarify it's for conceptual/ranked semantic retrieval, and points agents to `find_content` for literal-match enumeration.
- No behavioral changes — parameter names, return shape, and search logic all unchanged.

Closes #141. The docstring forward-references `find_content` (#142); harmless if that tool isn't registered yet.

## Test plan
- [x] `tests/test_search.py` — all 65 tests pass unchanged.
- [ ] Manual: agents pulling `tools/list` see the disambiguated title and description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)