### PR TITLE
feat(mcp): add find_content tool for literal/regex enumeration

### DIFF
--- a/stash_mcp/config.py
+++ b/stash_mcp/config.py
@@ -64,6 +64,11 @@ class Config:
     SEARCH_CHUNK_SIZE: int = int(os.getenv("STASH_SEARCH_CHUNK_SIZE", "1000"))
     SEARCH_CHUNK_OVERLAP: int = int(os.getenv("STASH_SEARCH_CHUNK_OVERLAP", "100"))
 
+    # Find tool settings
+    FIND_MAX_RESULTS_CEILING: int = int(
+        os.getenv("STASH_FIND_MAX_RESULTS_CEILING", "500")
+    )
+
     # Model cache directory (for HuggingFace/sentence-transformers weights)
     MODEL_CACHE_DIR: Path = Path(
         os.getenv("STASH_MODEL_CACHE_DIR", "/data/models")

--- a/stash_mcp/filesystem.py
+++ b/stash_mcp/filesystem.py
@@ -243,6 +243,27 @@ class FileSystem:
             logger.error(f"Error reading file '{relative_path}': {e}")
             raise FileSystemError(f"Failed to read file: {e}")
 
+    def try_read_text(self, relative_path: str) -> str | None:
+        """Best-effort UTF-8 read for bulk-scan callers.
+
+        Returns the file content on success, or None if the file does not
+        exist, is not a file, is outside the content directory, or fails
+        to decode as UTF-8. Decode/IO failures are logged at debug level
+        only — this is intended for tools like find_content that walk
+        many files and expect occasional skips.
+        """
+        try:
+            full_path = self._resolve_path(relative_path)
+        except InvalidPathError:
+            return None
+        if not full_path.is_file():
+            return None
+        try:
+            return full_path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError) as e:
+            logger.debug("try_read_text skipping '%s': %s", relative_path, e)
+            return None
+
     def write_file(self, relative_path: str, content: str) -> None:
         """Write content to file.
 

--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -104,6 +104,32 @@ def _get_mime_type(path: str) -> str:
     return MIME_TYPES.get(suffix, "text/plain")
 
 
+# Mime types that find_content treats as text-searchable. Anything outside
+# this set (images, binaries) is skipped without attempting to read.
+_SEARCHABLE_MIMES: frozenset[str] = frozenset({
+    "text/markdown",
+    "text/plain",
+    "application/json",
+    "application/x-yaml",
+    "application/xml",
+    "text/html",
+    "text/css",
+    "application/javascript",
+    "application/typescript",
+    "text/x-python",
+    "text/csv",
+    "text/tab-separated-values",
+    "application/toml",
+    "text/x-rst",
+    "text/x-mermaid",
+    "text/x-gantt",
+})
+
+
+def _is_searchable(path: str) -> bool:
+    return _get_mime_type(path) in _SEARCHABLE_MIMES
+
+
 def _get_description(fs: FileSystem, path: str) -> str:
     """Get description for a file from frontmatter or first line."""
     try:
@@ -762,6 +788,124 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                     "error": str(exc),
                 })
         return {"results": results}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            title="Find literal matches in content",
+            readOnlyHint=True,
+            openWorldHint=False,
+        )
+    )
+    async def find_content(
+        pattern: str,
+        is_regex: bool = False,
+        case_sensitive: bool = False,
+        max_results: int = 50,
+        file_types: str | None = None,
+        path_prefix: str | None = None,
+        context_lines: int = 0,
+    ) -> dict:
+        """Find every line matching a literal string or regex.
+
+        Exhaustive enumeration, not ranked retrieval. Use this for
+        completeness queries: every reference to a symbol, every file
+        containing an env var, every match of an error string.
+
+        For conceptual queries ("how does X work"), use search_content.
+
+        Args:
+            pattern: Literal substring (default) or regex (when is_regex=True).
+            is_regex: Treat pattern as a Python regex.
+            case_sensitive: Match case-sensitively. Default false.
+            max_results: Hard cap on total matches returned. Default 50.
+            file_types: Optional comma-separated file extensions
+                (e.g. ".md,.py").
+            path_prefix: Optional path prefix to limit the search
+                (e.g. "docs/" restricts to that subtree).
+            context_lines: Lines of context to include before and after
+                each match. Default 0, max 10.
+        Returns:
+            A dict with 'matches' (list of {file_path, line_number, line,
+            context_before, context_after}), 'truncated' (bool), and
+            'files_scanned' (int).
+        """
+        if not pattern:
+            raise ValueError("pattern must be a non-empty string")
+        if max_results < 1:
+            raise ValueError("max_results must be a positive integer")
+        if max_results > Config.FIND_MAX_RESULTS_CEILING:
+            raise ValueError(
+                f"max_results exceeds ceiling of {Config.FIND_MAX_RESULTS_CEILING}"
+            )
+        if context_lines < 0:
+            raise ValueError("context_lines must be non-negative")
+        if context_lines > 10:
+            raise ValueError("context_lines capped at 10")
+
+        flags = 0 if case_sensitive else re.IGNORECASE
+        if is_regex:
+            try:
+                compiled = re.compile(pattern, flags)
+            except re.error as e:
+                raise ValueError(f"Invalid regex: {e}")
+        else:
+            compiled = re.compile(re.escape(pattern), flags)
+
+        types_list = None
+        if file_types:
+            types_list = [t.strip() for t in file_types.split(",") if t.strip()]
+
+        try:
+            all_files = await asyncio.to_thread(
+                filesystem.list_all_files, path_prefix or ""
+            )
+        except InvalidPathError as exc:
+            raise ValueError(str(exc))
+
+        matches: list[dict] = []
+        files_scanned = 0
+        truncated = False
+
+        for fp in all_files:
+            if not _is_searchable(fp):
+                continue
+            if types_list and not any(fp.endswith(ext) for ext in types_list):
+                continue
+            try:
+                content = await asyncio.to_thread(filesystem.read_file, fp)
+            except Exception as exc:
+                logger.debug("find_content skipping %s: %s", fp, exc)
+                continue
+            files_scanned += 1
+            lines = content.splitlines()
+            for i, line in enumerate(lines, start=1):
+                if compiled.search(line):
+                    ctx_before = (
+                        lines[max(0, i - 1 - context_lines):i - 1]
+                        if context_lines else []
+                    )
+                    ctx_after = (
+                        lines[i:i + context_lines]
+                        if context_lines else []
+                    )
+                    matches.append({
+                        "file_path": fp,
+                        "line_number": i,
+                        "line": line,
+                        "context_before": ctx_before,
+                        "context_after": ctx_after,
+                    })
+                    if len(matches) >= max_results:
+                        truncated = True
+                        break
+            if truncated:
+                break
+
+        return {
+            "matches": matches,
+            "truncated": truncated,
+            "files_scanned": files_scanned,
+        }
 
     if not Config.READ_ONLY:
 

--- a/stash_mcp/mcp_server.py
+++ b/stash_mcp/mcp_server.py
@@ -127,7 +127,12 @@ _SEARCHABLE_MIMES: frozenset[str] = frozenset({
 
 
 def _is_searchable(path: str) -> bool:
-    return _get_mime_type(path) in _SEARCHABLE_MIMES
+    # Require a known extension. Falling back through _get_mime_type would
+    # treat unknown suffixes (.pdf, .bin, no extension at all) as
+    # "text/plain" and let them through the allowlist.
+    suffix = PurePosixPath(path).suffix.lower()
+    mime = MIME_TYPES.get(suffix)
+    return mime is not None and mime in _SEARCHABLE_MIMES
 
 
 def _get_description(fs: FileSystem, path: str) -> str:
@@ -847,7 +852,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
             try:
                 compiled = re.compile(pattern, flags)
             except re.error as e:
-                raise ValueError(f"Invalid regex: {e}")
+                raise ValueError(f"Invalid regex: {e}") from e
         else:
             compiled = re.compile(re.escape(pattern), flags)
 
@@ -860,7 +865,7 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 filesystem.list_all_files, path_prefix or ""
             )
         except InvalidPathError as exc:
-            raise ValueError(str(exc))
+            raise ValueError(str(exc)) from exc
 
         matches: list[dict] = []
         files_scanned = 0
@@ -871,10 +876,8 @@ def create_mcp_server(filesystem: FileSystem, search_engine=None, git_backend=No
                 continue
             if types_list and not any(fp.endswith(ext) for ext in types_list):
                 continue
-            try:
-                content = await asyncio.to_thread(filesystem.read_file, fp)
-            except Exception as exc:
-                logger.debug("find_content skipping %s: %s", fp, exc)
+            content = await asyncio.to_thread(filesystem.try_read_text, fp)
+            if content is None:
                 continue
             files_scanned += 1
             lines = content.splitlines()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -139,6 +139,7 @@ async def test_list_tools(mcp_server):
     assert "move_content_batch" in tool_names
     assert "inspect_content_structure" in tool_names
     assert "inspect_content_structure_batch" in tool_names
+    assert "find_content" in tool_names
 
 
 async def test_create_content_tool(temp_fs, mock_context):
@@ -1414,3 +1415,199 @@ async def test_inspect_content_structure_batch_all_missing(temp_fs):
         assert r["title"] is None
         assert r["sections"] is None
         assert r["error"] is not None
+
+
+# --- find_content tests ---
+
+
+def _find_data(result):
+    import json
+    return json.loads(str(result.content[0].text))
+
+
+@pytest.mark.anyio
+async def test_find_content_literal_match(temp_fs):
+    """Literal substring match returns every occurrence."""
+    temp_fs.write_file("a.md", "alpha\nfoo bar\nbaz")
+    temp_fs.write_file("b.md", "foo again\nnope")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(await tool.run({"pattern": "foo"}))
+    paths = sorted((m["file_path"], m["line_number"]) for m in data["matches"])
+    assert paths == [("a.md", 2), ("b.md", 1)]
+    assert data["truncated"] is False
+    assert data["files_scanned"] == 2
+
+
+@pytest.mark.anyio
+async def test_find_content_literal_treats_metacharacters_as_literal(temp_fs):
+    """Regex metacharacters in literal mode are escaped, not interpreted."""
+    temp_fs.write_file("a.md", "value: 1.0\nvalue: 1X0")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(await tool.run({"pattern": "1.0"}))
+    line_nums = [m["line_number"] for m in data["matches"]]
+    assert line_nums == [1]
+
+
+@pytest.mark.anyio
+async def test_find_content_regex_match(temp_fs):
+    """Regex mode interprets metacharacters."""
+    temp_fs.write_file("a.md", "value: 1.0\nvalue: 1X0\nvalue: 1_0")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(await tool.run({"pattern": r"1.0", "is_regex": True}))
+    assert len(data["matches"]) == 3
+
+
+@pytest.mark.anyio
+async def test_find_content_invalid_regex(temp_fs):
+    """Invalid regex raises ValueError."""
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    with pytest.raises(ValueError, match="Invalid regex"):
+        await tool.run({"pattern": "[unclosed", "is_regex": True})
+
+
+@pytest.mark.anyio
+async def test_find_content_case_insensitive_default(temp_fs):
+    """Default is case-insensitive."""
+    temp_fs.write_file("a.md", "Foo\nFOO\nfoo")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(await tool.run({"pattern": "foo"}))
+    assert len(data["matches"]) == 3
+
+
+@pytest.mark.anyio
+async def test_find_content_case_sensitive(temp_fs):
+    """case_sensitive=True respects case."""
+    temp_fs.write_file("a.md", "Foo\nFOO\nfoo")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(
+        await tool.run({"pattern": "foo", "case_sensitive": True})
+    )
+    line_nums = [m["line_number"] for m in data["matches"]]
+    assert line_nums == [3]
+
+
+@pytest.mark.anyio
+async def test_find_content_file_types_filter(temp_fs):
+    """file_types restricts matches to listed extensions."""
+    temp_fs.write_file("a.md", "needle")
+    temp_fs.write_file("b.py", "needle")
+    temp_fs.write_file("c.json", '"needle"')
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(
+        await tool.run({"pattern": "needle", "file_types": ".md,.py"})
+    )
+    paths = sorted({m["file_path"] for m in data["matches"]})
+    assert paths == ["a.md", "b.py"]
+
+
+@pytest.mark.anyio
+async def test_find_content_path_prefix(temp_fs):
+    """path_prefix restricts the walk to a subtree."""
+    temp_fs.write_file("docs/a.md", "needle")
+    temp_fs.write_file("src/b.md", "needle")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(
+        await tool.run({"pattern": "needle", "path_prefix": "docs"})
+    )
+    paths = [m["file_path"] for m in data["matches"]]
+    assert paths == ["docs/a.md"]
+
+
+@pytest.mark.anyio
+async def test_find_content_context_lines(temp_fs):
+    """context_lines includes surrounding lines."""
+    temp_fs.write_file("a.md", "line1\nline2\nMATCH\nline4\nline5")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(
+        await tool.run({"pattern": "MATCH", "context_lines": 2})
+    )
+    m = data["matches"][0]
+    assert m["context_before"] == ["line1", "line2"]
+    assert m["context_after"] == ["line4", "line5"]
+
+
+@pytest.mark.anyio
+async def test_find_content_max_results_truncates(temp_fs):
+    """max_results caps total matches and sets truncated flag."""
+    temp_fs.write_file("a.md", "hit\n" * 10)
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(
+        await tool.run({"pattern": "hit", "max_results": 3})
+    )
+    assert len(data["matches"]) == 3
+    assert data["truncated"] is True
+
+
+@pytest.mark.anyio
+async def test_find_content_max_results_ceiling(temp_fs):
+    """max_results above ceiling raises ValueError."""
+    from stash_mcp.config import Config
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    with pytest.raises(ValueError, match="exceeds ceiling"):
+        await tool.run(
+            {"pattern": "x", "max_results": Config.FIND_MAX_RESULTS_CEILING + 1}
+        )
+
+
+@pytest.mark.anyio
+async def test_find_content_empty_pattern(temp_fs):
+    """Empty pattern raises ValueError."""
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    with pytest.raises(ValueError, match="non-empty"):
+        await tool.run({"pattern": ""})
+
+
+@pytest.mark.anyio
+async def test_find_content_context_lines_capped(temp_fs):
+    """context_lines above 10 raises ValueError."""
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    with pytest.raises(ValueError, match="capped at 10"):
+        await tool.run({"pattern": "x", "context_lines": 11})
+
+
+@pytest.mark.anyio
+async def test_find_content_empty_results(temp_fs):
+    """No matches returns empty list, not an error."""
+    temp_fs.write_file("a.md", "nothing here")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(await tool.run({"pattern": "absent"}))
+    assert data["matches"] == []
+    assert data["truncated"] is False
+    assert data["files_scanned"] == 1
+
+
+@pytest.mark.anyio
+async def test_find_content_skips_binary_files(temp_fs):
+    """Binary files (by MIME) are skipped without errors."""
+    temp_fs.write_file("a.md", "needle")
+    # PNG: not in _SEARCHABLE_MIMES
+    (temp_fs.content_dir / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nneedle")
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    data = _find_data(await tool.run({"pattern": "needle"}))
+    paths = [m["file_path"] for m in data["matches"]]
+    assert paths == ["a.md"]
+    assert data["files_scanned"] == 1
+
+
+@pytest.mark.anyio
+async def test_find_content_invalid_path_prefix(temp_fs):
+    """path_prefix that escapes the content root raises ValueError."""
+    mcp = create_mcp_server(temp_fs)
+    tool = await mcp.get_tool("find_content")
+    with pytest.raises(ValueError):
+        await tool.run({"pattern": "x", "path_prefix": "../escape"})


### PR DESCRIPTION
## Summary

Adds a new read-only MCP tool `find_content` that walks the content tree and returns every line matching a literal substring (default) or Python regex. Complements `search_content` (ranked semantic retrieval, top-k) by handling completeness queries — every file mentioning a symbol, every reference to an env var, every occurrence of an error string.

- Honors `STASH_CONTENT_PATHS` filtering via `FileSystem.list_all_files`.
- Skips non-text MIME types via a new `_SEARCHABLE_MIMES` allowlist; never tries to read binary files.
- Literal mode escapes regex metacharacters via `re.escape`. Invalid regex surfaces as `ValueError` with the regex error message.
- New `STASH_FIND_MAX_RESULTS_CEILING` env var (default 500) protects the context window from runaway result sets.
- `context_lines` capped at 10 to bound response size.
- Registered unconditionally (read-only, safe in both `READ_ONLY` and read-write modes).

Closes #142.

## Test plan
- [x] 16 new `find_content` tests pass, covering: literal match, regex, case sensitivity, file_types filter, path_prefix filter, context_lines, max_results truncation flag, ceiling enforcement, empty pattern/results, invalid regex, binary file skip, path escape rejection.
- [x] `test_list_tools` updated to assert `find_content` is registered.
- [ ] Manual: agent invokes `find_content` for completeness queries and sees structured `{matches, truncated, files_scanned}` response.

## Reviewer notes

The docstring forward-references `search_content` (the previously merged #143 already references `find_content`) — the two are designed to be mutually disambiguating from the agent's perspective.

Pre-existing test_ui.py failures are unrelated (missing `bs4` dep) and not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)