### PR TITLE
feat(search): MMR diversification + per-file cap + recency reranking

### DIFF
--- a/stash_mcp/config.py
+++ b/stash_mcp/config.py
@@ -69,6 +69,24 @@ class Config:
         os.getenv("STASH_FIND_MAX_RESULTS_CEILING", "500")
     )
 
+    # Search ranking — MMR diversification
+    SEARCH_MMR_ENABLED: bool = (
+        os.getenv("STASH_SEARCH_MMR_ENABLED", "true").lower() == "true"
+    )
+    SEARCH_MMR_LAMBDA: float = float(os.getenv("STASH_SEARCH_MMR_LAMBDA", "0.7"))
+    SEARCH_MAX_PER_FILE: int = int(os.getenv("STASH_SEARCH_MAX_PER_FILE", "2"))
+    SEARCH_CANDIDATE_POOL_MULTIPLIER: int = int(
+        os.getenv("STASH_SEARCH_CANDIDATE_POOL_MULTIPLIER", "6")
+    )
+
+    # Search ranking — recency boost from git blame
+    SEARCH_RECENCY_WEIGHT: float = float(
+        os.getenv("STASH_SEARCH_RECENCY_WEIGHT", "0.0")
+    )
+    SEARCH_RECENCY_HALF_LIFE_DAYS: float = float(
+        os.getenv("STASH_SEARCH_RECENCY_HALF_LIFE_DAYS", "180")
+    )
+
     # Model cache directory (for HuggingFace/sentence-transformers weights)
     MODEL_CACHE_DIR: Path = Path(
         os.getenv("STASH_MODEL_CACHE_DIR", "/data/models")

--- a/stash_mcp/main.py
+++ b/stash_mcp/main.py
@@ -128,6 +128,12 @@ def _create_search_engine():
             anthropic_api_key=os.getenv("ANTHROPIC_API_KEY"),
             chunk_size=Config.SEARCH_CHUNK_SIZE,
             chunk_overlap=Config.SEARCH_CHUNK_OVERLAP,
+            mmr_enabled=Config.SEARCH_MMR_ENABLED,
+            mmr_lambda=Config.SEARCH_MMR_LAMBDA,
+            max_per_file=Config.SEARCH_MAX_PER_FILE,
+            candidate_pool_multiplier=Config.SEARCH_CANDIDATE_POOL_MULTIPLIER,
+            recency_weight=Config.SEARCH_RECENCY_WEIGHT,
+            recency_half_life_days=Config.SEARCH_RECENCY_HALF_LIFE_DAYS,
         )
         logger.info(
             f"Search engine initialised (model={Config.SEARCH_EMBEDDER_MODEL}, "

--- a/stash_mcp/search.py
+++ b/stash_mcp/search.py
@@ -891,21 +891,24 @@ class SearchEngine:
                 if any(r.get("file_path", "").endswith(ext) for ext in file_types)
             ]
 
-        # Fetch blame once per unique file (in parallel) when either
-        # recency reranking or display enrichment will need it.
+        # Blame is needed up-front only when recency reranking is on
+        # (it needs every candidate's timestamp before truncation). When
+        # recency is off, defer the fetch until after truncation so we
+        # only pay for the files that actually make it into the result.
         blame_cache: dict[str, list] = {}
-        need_blame = self._git_backend is not None and raw_results
-        if need_blame:
-            unique_paths = list({r.get("file_path", "") for r in raw_results if r.get("file_path")})
-            blame_cache = await self._fetch_blame_batch(unique_paths)
-
-        # Recency reranking: blend in an exponential-decay boost based
-        # on the freshest blame timestamp for each file. Off by default.
-        if (
+        recency_enabled = (
             self.recency_weight > 0
             and self._git_backend is not None
             and raw_results
-        ):
+        )
+        if recency_enabled:
+            unique_paths = list({
+                r.get("file_path", "")
+                for r in raw_results
+                if r.get("file_path")
+            })
+            blame_cache = await self._fetch_blame_batch(unique_paths)
+
             reranked = []
             for r in raw_results:
                 semantic = float(r.get("score", 0.0))
@@ -938,7 +941,18 @@ class SearchEngine:
             if len(results) >= max_results:
                 break
 
-        if self._git_backend is not None:
+        if self._git_backend is not None and results:
+            # Backfill blame for any final-result files not already in
+            # the cache (i.e. the recency-off path that skipped the
+            # candidate-pool fetch).
+            missing_paths = list({
+                r.file_path
+                for r in results
+                if r.file_path and r.file_path not in blame_cache
+            })
+            if missing_paths:
+                fetched = await self._fetch_blame_batch(missing_paths)
+                blame_cache.update(fetched)
             for result in results:
                 blame_lines = blame_cache.get(result.file_path)
                 if blame_lines:

--- a/stash_mcp/search.py
+++ b/stash_mcp/search.py
@@ -202,6 +202,93 @@ class VectorStore:
 
         return results
 
+    def search_mmr(
+        self,
+        query_embedding: list[float],
+        *,
+        top_n: int = 10,
+        candidate_pool: int = 30,
+        mmr_lambda: float = 0.7,
+        max_per_file: int | None = 2,
+    ) -> list[dict]:
+        """Cosine retrieval followed by Maximal Marginal Relevance reranking.
+
+        Pulls ``candidate_pool`` raw chunks by cosine similarity, then
+        greedily picks up to ``top_n`` of them while balancing relevance
+        against diversity. ``mmr_lambda=1.0`` collapses to pure cosine
+        ordering; ``0.0`` ignores relevance and maximises diversity.
+        ``max_per_file`` (if set) hard-caps how many chunks from any one
+        file can land in the final result.
+
+        Returns the same metadata-with-score shape as ``search``.
+        """
+        if self._vectors is None or len(self._vectors) == 0:
+            return []
+        if top_n <= 0 or candidate_pool <= 0:
+            return []
+
+        import numpy as np
+
+        query = np.array(query_embedding, dtype=np.float32)
+        q_norm = np.linalg.norm(query)
+        if q_norm == 0:
+            return []
+        query = query / q_norm
+
+        norms = np.linalg.norm(self._vectors, axis=1, keepdims=True)
+        norms = np.maximum(norms, 1e-10)
+        normed = self._vectors / norms
+
+        similarities = normed @ query
+        pool_size = min(candidate_pool, len(similarities))
+        # argpartition is O(n) vs argsort's O(n log n); fine either way at
+        # this scale, but argsort makes the post-sort cleaner.
+        pool_indices = np.argsort(similarities)[-pool_size:][::-1]
+
+        # Drop non-positive scores up front — they would never beat any
+        # positive candidate even with the diversity term.
+        pool = [int(i) for i in pool_indices if similarities[int(i)] > 0]
+        if not pool:
+            return []
+
+        selected: list[int] = []
+        per_file: dict[str, int] = {}
+
+        while pool and len(selected) < top_n:
+            if not selected:
+                best = pool[0]
+                best_pos = 0
+            else:
+                # Cosine sim between each remaining candidate and the
+                # already-selected set, using pre-normalised vectors.
+                selected_mat = normed[selected]
+                cand_mat = normed[pool]
+                cross_sim = cand_mat @ selected_mat.T
+                max_sim = cross_sim.max(axis=1)
+                rel = similarities[pool]
+                mmr_scores = mmr_lambda * rel - (1 - mmr_lambda) * max_sim
+                best_pos = int(np.argmax(mmr_scores))
+                best = pool[best_pos]
+
+            file_path = self._metadata[best].get("file_path", "")
+            if (
+                max_per_file is not None
+                and per_file.get(file_path, 0) >= max_per_file
+            ):
+                pool.pop(best_pos)
+                continue
+
+            selected.append(best)
+            per_file[file_path] = per_file.get(file_path, 0) + 1
+            pool.pop(best_pos)
+
+        results = []
+        for idx in selected:
+            result = dict(self._metadata[idx])
+            result["score"] = float(similarities[idx])
+            results.append(result)
+        return results
+
     def clear(self) -> None:
         """Remove all vectors and metadata."""
         self._vectors = None
@@ -384,6 +471,12 @@ class SearchEngine:
         git_backend=None,
         chunk_size: int = 1000,
         chunk_overlap: int = 100,
+        mmr_enabled: bool = True,
+        mmr_lambda: float = 0.7,
+        max_per_file: int = 2,
+        candidate_pool_multiplier: int = 6,
+        recency_weight: float = 0.0,
+        recency_half_life_days: float = 180.0,
     ):
         """Initialize the search engine.
 
@@ -400,6 +493,18 @@ class SearchEngine:
             git_backend: Optional GitBackend instance for blame-enriched results.
             chunk_size: Number of characters per chunk for the sliding window.
             chunk_overlap: Number of characters to overlap between adjacent chunks.
+            mmr_enabled: Apply MMR diversification + per-file cap to the
+                cosine candidate pool before truncating to max_results.
+            mmr_lambda: MMR relevance/diversity balance (1.0 = relevance-only,
+                0.0 = diversity-only). Default 0.7.
+            max_per_file: Hard cap on chunks from a single file in the
+                final result set.
+            candidate_pool_multiplier: How many cosine candidates to fetch
+                per requested result (e.g. 6 means fetch 30 for max_results=5).
+            recency_weight: Blend factor for the git-blame recency boost
+                (0.0 = ignore recency, 1.0 = recency only). Off by default.
+            recency_half_life_days: Days for the recency boost to decay
+                from 1.0 to 0.5. Default 180 (6 months).
         """
         self.content_dir = content_dir
         self.index_dir = index_dir
@@ -413,6 +518,12 @@ class SearchEngine:
         self._git_backend = git_backend
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
+        self.mmr_enabled = mmr_enabled
+        self.mmr_lambda = mmr_lambda
+        self.max_per_file = max_per_file
+        self.candidate_pool_multiplier = max(1, candidate_pool_multiplier)
+        self.recency_weight = recency_weight
+        self.recency_half_life_days = recency_half_life_days
 
         # Validate numpy dependency at init time so we fail fast
         # rather than crashing on first file operation.
@@ -752,18 +863,69 @@ class SearchEngine:
 
         query_embedding = await self._embed_query(query)
 
-        # Get more results than needed so we can filter
-        fetch_n = max_results * 3 if file_types else max_results
+        # Fetch a larger candidate pool so MMR + per-file cap + file_types
+        # filter have room to work. file_types over-fetches further since
+        # the filter happens post-retrieval.
+        candidate_pool = max(
+            max_results * self.candidate_pool_multiplier,
+            max_results,
+        )
+        fetch_n = candidate_pool * 3 if file_types else candidate_pool
+
         async with self._lock:
-            raw_results = self.store.search(query_embedding, top_n=fetch_n)
+            if self.mmr_enabled:
+                raw_results = self.store.search_mmr(
+                    query_embedding,
+                    top_n=fetch_n,
+                    candidate_pool=fetch_n,
+                    mmr_lambda=self.mmr_lambda,
+                    max_per_file=self.max_per_file,
+                )
+            else:
+                raw_results = self.store.search(query_embedding, top_n=fetch_n)
+
+        if file_types:
+            raw_results = [
+                r
+                for r in raw_results
+                if any(r.get("file_path", "").endswith(ext) for ext in file_types)
+            ]
+
+        # Fetch blame once per unique file (in parallel) when either
+        # recency reranking or display enrichment will need it.
+        blame_cache: dict[str, list] = {}
+        need_blame = self._git_backend is not None and raw_results
+        if need_blame:
+            unique_paths = list({r.get("file_path", "") for r in raw_results if r.get("file_path")})
+            blame_cache = await self._fetch_blame_batch(unique_paths)
+
+        # Recency reranking: blend in an exponential-decay boost based
+        # on the freshest blame timestamp for each file. Off by default.
+        if (
+            self.recency_weight > 0
+            and self._git_backend is not None
+            and raw_results
+        ):
+            reranked = []
+            for r in raw_results:
+                semantic = float(r.get("score", 0.0))
+                ts = self._most_recent_timestamp(
+                    blame_cache.get(r.get("file_path", ""), [])
+                )
+                recency = self._recency_boost(ts)
+                final = (
+                    semantic * (1 - self.recency_weight)
+                    + recency * self.recency_weight
+                )
+                rr = dict(r)
+                rr["score"] = final
+                reranked.append(rr)
+            reranked.sort(key=lambda d: d.get("score", 0.0), reverse=True)
+            raw_results = reranked
 
         results: list[SearchResult] = []
         for r in raw_results:
             fp = r.get("file_path", "")
-            if file_types:
-                if not any(fp.endswith(ext) for ext in file_types):
-                    continue
-
             results.append(
                 SearchResult(
                     file_path=fp,
@@ -776,27 +938,60 @@ class SearchEngine:
             if len(results) >= max_results:
                 break
 
-        # Lazy blame enrichment: annotate each result when git_backend is set
         if self._git_backend is not None:
             for result in results:
-                await self._enrich_with_blame(result)
+                blame_lines = blame_cache.get(result.file_path)
+                if blame_lines:
+                    await self._enrich_with_blame(result, blame_lines)
 
         return results
 
-    async def _enrich_with_blame(self, result: "SearchResult") -> None:
-        """Populate blame fields on *result* using the configured git backend.
+    async def _fetch_blame_batch(
+        self, file_paths: list[str]
+    ) -> dict[str, list]:
+        """Fetch blame for many files in parallel, returning {path: lines}."""
 
-        Uses the chunk's text content to locate its approximate line range,
-        then picks the most recently changed line's metadata.
+        async def _one(path: str) -> tuple[str, list]:
+            try:
+                lines = await asyncio.to_thread(self._git_backend.blame, path)
+            except Exception as e:
+                logger.debug("blame fetch failed for %s: %s", path, e)
+                return path, []
+            return path, lines or []
+
+        pairs = await asyncio.gather(*(_one(p) for p in file_paths))
+        return dict(pairs)
+
+    @staticmethod
+    def _most_recent_timestamp(blame_lines: list):
+        """Return the most recent timestamp in a blame line list, or None."""
+        if not blame_lines:
+            return None
+        return max(bl.timestamp for bl in blame_lines)
+
+    def _recency_boost(self, last_changed_at) -> float:
+        """Exponential-decay boost in [0, 1]. Files without history → 0.5."""
+        if last_changed_at is None:
+            return 0.5
+        from datetime import datetime, timezone
+        import math
+
+        ts = last_changed_at
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - ts).days
+        if self.recency_half_life_days <= 0:
+            return 1.0 if age_days <= 0 else 0.0
+        return math.exp(-math.log(2) * max(age_days, 0) / self.recency_half_life_days)
+
+    async def _enrich_with_blame(
+        self, result: "SearchResult", blame_lines: list
+    ) -> None:
+        """Populate blame fields on *result* from a pre-fetched blame list.
+
+        Scopes blame to the chunk's line range when possible, then takes
+        the most recent line in that range.
         """
-        try:
-            blame_lines = await asyncio.to_thread(
-                self._git_backend.blame, result.file_path
-            )
-        except Exception as e:
-            logger.debug("blame enrichment failed for %s: %s", result.file_path, e)
-            return
-
         if not blame_lines:
             return
 

--- a/stash_mcp/server.py
+++ b/stash_mcp/server.py
@@ -78,6 +78,12 @@ def _create_search_engine(filesystem: FileSystem):
             anthropic_api_key=os.getenv("ANTHROPIC_API_KEY"),
             chunk_size=Config.SEARCH_CHUNK_SIZE,
             chunk_overlap=Config.SEARCH_CHUNK_OVERLAP,
+            mmr_enabled=Config.SEARCH_MMR_ENABLED,
+            mmr_lambda=Config.SEARCH_MMR_LAMBDA,
+            max_per_file=Config.SEARCH_MAX_PER_FILE,
+            candidate_pool_multiplier=Config.SEARCH_CANDIDATE_POOL_MULTIPLIER,
+            recency_weight=Config.SEARCH_RECENCY_WEIGHT,
+            recency_half_life_days=Config.SEARCH_RECENCY_HALF_LIFE_DAYS,
         )
         engine._filesystem = filesystem
         logger.info(f"Search engine initialised (model={Config.SEARCH_EMBEDDER_MODEL})")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -993,3 +993,254 @@ class TestSearchIndexIntegrity:
 
             results = store.search([0.0, 1.0])
             assert results[0]["file_path"] == "notes.md"
+
+
+# --- MMR + per-file cap tests ---
+
+
+class TestVectorStoreMMR:
+    """search_mmr() reranks the cosine pool for diversity + per-file cap."""
+
+    def _store(self, tmpdir):
+        store = VectorStore(Path(tmpdir) / "vectors.pkl")
+        # vec_a and vec_b nearly identical, vec_c has a small positive
+        # component on the query axis so it survives the >0 filter but
+        # is far away from a/b in the orthogonal direction.
+        store.add(
+            [
+                [1.0, 0.0, 0.0],
+                [0.99, 0.1, 0.0],
+                [0.1, 0.0, 1.0],
+            ],
+            [
+                {"file_path": "a.md", "chunk_index": 0, "content": "A"},
+                {"file_path": "b.md", "chunk_index": 0, "content": "B"},
+                {"file_path": "c.md", "chunk_index": 0, "content": "C"},
+            ],
+        )
+        return store
+
+    def test_mmr_diversifies_vs_pure_cosine(self):
+        """MMR with lambda<1 prefers the diverse vector over the redundant one."""
+        with TemporaryDirectory() as tmpdir:
+            store = self._store(tmpdir)
+            cosine = store.search([1.0, 0.0, 0.0], top_n=2)
+            assert [r["file_path"] for r in cosine] == ["a.md", "b.md"]
+
+            mmr = store.search_mmr(
+                [1.0, 0.0, 0.0], top_n=2, candidate_pool=3, mmr_lambda=0.3
+            )
+            assert [r["file_path"] for r in mmr] == ["a.md", "c.md"]
+
+    def test_mmr_lambda_one_matches_cosine(self):
+        """mmr_lambda=1.0 collapses to pure relevance ordering."""
+        with TemporaryDirectory() as tmpdir:
+            store = self._store(tmpdir)
+            mmr = store.search_mmr(
+                [1.0, 0.0, 0.0],
+                top_n=3,
+                candidate_pool=3,
+                mmr_lambda=1.0,
+                max_per_file=None,
+            )
+            assert [r["file_path"] for r in mmr] == ["a.md", "b.md", "c.md"]
+
+    def test_mmr_enforces_max_per_file(self):
+        """When all chunks come from one file, max_per_file caps the result."""
+        with TemporaryDirectory() as tmpdir:
+            store = VectorStore(Path(tmpdir) / "vectors.pkl")
+            store.add(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.95, 0.05, 0.0],
+                    [0.9, 0.1, 0.0],
+                ],
+                [
+                    {"file_path": "same.md", "chunk_index": i, "content": f"C{i}"}
+                    for i in range(3)
+                ],
+            )
+            mmr = store.search_mmr(
+                [1.0, 0.0, 0.0],
+                top_n=5,
+                candidate_pool=10,
+                mmr_lambda=1.0,
+                max_per_file=2,
+            )
+            assert len(mmr) == 2
+            assert all(r["file_path"] == "same.md" for r in mmr)
+
+    def test_mmr_empty_store_returns_empty(self):
+        with TemporaryDirectory() as tmpdir:
+            store = VectorStore(Path(tmpdir) / "vectors.pkl")
+            assert store.search_mmr([1.0, 0.0, 0.0], top_n=5) == []
+
+    def test_mmr_zero_query_returns_empty(self):
+        with TemporaryDirectory() as tmpdir:
+            store = self._store(tmpdir)
+            assert store.search_mmr([0.0, 0.0, 0.0], top_n=2) == []
+
+
+# --- SearchEngine recency reranking tests ---
+
+
+class TestSearchEngineRecency:
+    """SearchEngine blends a recency boost into the final score when enabled."""
+
+    @pytest.fixture
+    def engine_with_recency(self, tmp_path):
+        """Build a small engine with a fake git_backend serving controlled blame."""
+        from datetime import datetime, timedelta, timezone
+        from stash_mcp.git_backend import BlameLine
+
+        content_dir = tmp_path / "content"
+        index_dir = tmp_path / "index"
+        content_dir.mkdir()
+        index_dir.mkdir()
+        (content_dir / "fresh.md").write_text("authentication content")
+        (content_dir / "stale.md").write_text("authentication content")
+
+        now = datetime.now(timezone.utc)
+
+        class FakeGit:
+            def blame(self, path):
+                ts = now if path == "fresh.md" else now - timedelta(days=720)
+                return [
+                    BlameLine(
+                        line_number=1,
+                        commit_hash="abc",
+                        author="dev",
+                        timestamp=ts,
+                        summary="msg",
+                        content="authentication content",
+                    )
+                ]
+
+        engine = SearchEngine(
+            content_dir=content_dir,
+            index_dir=index_dir,
+            embed_fn=mock_embed,
+            git_backend=FakeGit(),
+            mmr_enabled=False,
+            recency_weight=0.0,
+            recency_half_life_days=180.0,
+        )
+        return engine, now
+
+    async def test_recency_off_preserves_semantic_order(self, engine_with_recency):
+        """recency_weight=0 leaves ordering driven by semantic score alone."""
+        engine, _ = engine_with_recency
+        await engine.build_index(["fresh.md", "stale.md"])
+        # Both files have identical content → identical embeddings; the
+        # order is implementation-defined but blame must NOT swap them
+        # when recency is disabled.
+        results = await engine.search("authentication", max_results=2)
+        scores = [r.score for r in results]
+        # Scores equal because content is identical and recency is off.
+        assert scores[0] == pytest.approx(scores[1])
+
+    async def test_recency_on_boosts_fresh_over_stale(self, engine_with_recency):
+        """With recency_weight>0 and equal semantic scores, fresh wins."""
+        engine, _ = engine_with_recency
+        engine.recency_weight = 0.5
+        await engine.build_index(["fresh.md", "stale.md"])
+        results = await engine.search("authentication", max_results=2)
+        assert results[0].file_path == "fresh.md"
+        assert results[0].score > results[1].score
+
+    async def test_recency_neutral_for_unblamed_files(self, tmp_path):
+        """Files the git_backend cannot blame fall back to neutral (0.5) recency."""
+        from stash_mcp.git_backend import BlameLine
+
+        content_dir = tmp_path / "content"
+        index_dir = tmp_path / "index"
+        content_dir.mkdir()
+        index_dir.mkdir()
+        (content_dir / "tracked.md").write_text("authentication content")
+        (content_dir / "untracked.md").write_text("authentication content")
+
+        class PartialGit:
+            def blame(self, path):
+                if path == "untracked.md":
+                    return []
+                from datetime import datetime, timedelta, timezone
+                return [
+                    BlameLine(
+                        line_number=1,
+                        commit_hash="abc",
+                        author="dev",
+                        # 5 half-lives old → boost ~0.03
+                        timestamp=datetime.now(timezone.utc) - timedelta(days=900),
+                        summary="msg",
+                        content="authentication content",
+                    )
+                ]
+
+        engine = SearchEngine(
+            content_dir=content_dir,
+            index_dir=index_dir,
+            embed_fn=mock_embed,
+            git_backend=PartialGit(),
+            mmr_enabled=False,
+            recency_weight=0.5,
+            recency_half_life_days=180.0,
+        )
+        await engine.build_index(["tracked.md", "untracked.md"])
+        results = await engine.search("authentication", max_results=2)
+        # Untracked file gets neutral 0.5 recency; tracked file gets a
+        # near-zero recency (very old). Untracked should rank higher.
+        order = [r.file_path for r in results]
+        assert order[0] == "untracked.md"
+
+
+# --- MMR config integration tests ---
+
+
+class TestSearchEngineMMRConfig:
+    """SearchEngine pipeline behaviour with mmr_enabled toggled."""
+
+    async def test_mmr_caps_results_per_file(self, tmp_path):
+        """A single file with many overlapping chunks is capped by max_per_file."""
+        content_dir = tmp_path / "content"
+        index_dir = tmp_path / "index"
+        content_dir.mkdir()
+        index_dir.mkdir()
+        # Generate a long file so it produces many overlapping chunks.
+        body = "authentication " * 500
+        (content_dir / "auth.md").write_text(body)
+        (content_dir / "other.md").write_text("authentication once")
+
+        engine = SearchEngine(
+            content_dir=content_dir,
+            index_dir=index_dir,
+            embed_fn=mock_embed,
+            mmr_enabled=True,
+            max_per_file=2,
+            candidate_pool_multiplier=6,
+        )
+        await engine.build_index(["auth.md", "other.md"])
+        results = await engine.search("authentication", max_results=5)
+        auth_hits = [r for r in results if r.file_path == "auth.md"]
+        assert len(auth_hits) <= 2
+
+    async def test_mmr_disabled_skips_per_file_cap(self, tmp_path):
+        """mmr_enabled=False matches the legacy pipeline (no per-file cap)."""
+        content_dir = tmp_path / "content"
+        index_dir = tmp_path / "index"
+        content_dir.mkdir()
+        index_dir.mkdir()
+        body = "authentication " * 500
+        (content_dir / "auth.md").write_text(body)
+
+        engine = SearchEngine(
+            content_dir=content_dir,
+            index_dir=index_dir,
+            embed_fn=mock_embed,
+            mmr_enabled=False,
+            max_per_file=2,
+        )
+        await engine.build_index(["auth.md"])
+        results = await engine.search("authentication", max_results=5)
+        # No cap when MMR is off — all results may come from the one file.
+        assert all(r.file_path == "auth.md" for r in results)
+        assert len(results) > 2


### PR DESCRIPTION
## Summary

Two ranking-stage improvements that operate on a larger candidate pool (default 6× `max_results`) before truncating to the requested number of results.

### MMR diversification (default on)
- New `VectorStore.search_mmr()` reranks the cosine candidate pool via Maximal Marginal Relevance: each pick balances relevance against diversity from already-selected items.
- `mmr_lambda=1.0` collapses to pure cosine ordering (regression guard).
- `max_per_file` hard-caps how many chunks from one file land in the result, fixing the failure mode where overlapping sliding-window chunks from one file crowd out other content.

### Recency boost (default off)
- When `recency_weight > 0` and a `git_backend` is available, blame is fetched **once per unique file** in the candidate set (in parallel via `asyncio.gather`) and the freshest timestamp drives an exponential-decay boost: `boost = exp(-ln2 · age_days / half_life_days)`.
- `final_score = semantic·(1−w) + recency·w`. `half_life_days` default 180.
- Files without git history get neutral 0.5 — they don't get penalized.
- The cached blame is reused by the existing display-side `_enrich_with_blame` step, so we don't re-fetch.

### Pipeline order in `SearchEngine.search()`
embed → cosine fetch (candidate pool) → MMR + per-file cap → `file_types` filter → blame fetch (once per unique file) → recency blend → truncate → enrich.

### Config (env vars)
| Var | Default | Notes |
|---|---|---|
| `STASH_SEARCH_MMR_ENABLED` | `true` | Opt-out |
| `STASH_SEARCH_MMR_LAMBDA` | `0.7` | 1.0 = relevance-only, 0.0 = diversity-only |
| `STASH_SEARCH_MAX_PER_FILE` | `2` | Hard cap on chunks per file |
| `STASH_SEARCH_CANDIDATE_POOL_MULTIPLIER` | `6` | Candidate pool = mult × max_results |
| `STASH_SEARCH_RECENCY_WEIGHT` | `0.0` | Opt-in |
| `STASH_SEARCH_RECENCY_HALF_LIFE_DAYS` | `180` | 6 months |

Closes #139.

## Test plan
- [x] 10 new tests in `tests/test_search.py` cover: MMR diversity vs pure cosine, `mmr_lambda=1.0` regression to cosine, per-file cap at both store and engine level, recency boost ordering when two chunks tie semantically, neutral recency for unblamed files, `mmr_enabled=False` matches legacy behavior.
- [x] All 75 existing search tests still pass.
- [ ] Manual: query a real corpus with default MMR settings and confirm the result set is no longer crowded by overlapping chunks from one file.

## Reviewer notes
- Both `stash_mcp/main.py` and `stash_mcp/server.py` instantiate `SearchEngine` — both updated to pass the new params from `Config`.
- The `_enrich_with_blame` helper changed signature from `(result)` (fetches blame inside) to `(result, blame_lines)` (caller passes pre-fetched blame). No public-API impact.
- Composes cleanly with the upcoming hybrid retrieval issue (#140) — the fusion step there feeds the same downstream `MMR → recency → enrich` stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)